### PR TITLE
update Hyku to get solr endpoint fixes

### DIFF
--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build:
-    uses: scientist-softserv/actions/.github/workflows/build.yaml@v0.0.18
+    uses: scientist-softserv/actions/.github/workflows/build.yaml@v0.0.22
     secrets: inherit
     with:
       platforms: 'linux/amd64'
@@ -26,7 +26,7 @@ jobs:
 
   test:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.18
+    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.22
     with:
       confdir: '/app/samvera/hyrax-webapp/solr/conf'
       webTarget: hyku-web
@@ -35,7 +35,7 @@ jobs:
 
   lint:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.18
+    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.22
     with:
       webTarget: hyku-web
       workerTarget: hyku-worker

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build:
-    uses: scientist-softserv/actions/.github/workflows/build.yaml@v0.0.22
+    uses: scientist-softserv/actions/.github/workflows/build.yaml@v0.0.18
     secrets: inherit
     with:
       platforms: 'linux/amd64'
@@ -26,7 +26,7 @@ jobs:
 
   test:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.22
+    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.18
     with:
       confdir: '/app/samvera/hyrax-webapp/solr/conf'
       webTarget: hyku-web
@@ -35,7 +35,7 @@ jobs:
 
   lint:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.22
+    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.18
     with:
       webTarget: hyku-web
       workerTarget: hyku-worker


### PR DESCRIPTION
We're seeing an issue where some Solr requests are being sent to the wrong tenant, resulting in 404 errors. With this Hyku update, we'll get the following fixes related to Solr endpoints:

- https://github.com/samvera/hyku/pull/2179
- https://github.com/samvera/hyku/pull/2180
- https://github.com/samvera/hyku/pull/2182
