### PR TITLE
i318 Render `:resource_type` as text on UncaWork form

### DIFF
--- a/app/views/unca_works/edit_fields/_resource_type.html.erb
+++ b/app/views/unca_works/edit_fields/_resource_type.html.erb
@@ -1,0 +1,5 @@
+<%# OVERRIDE: Render as text instead of select to accommodate imported values that aren't included
+    in Hyku by default. This is intended to be a temporary workaround until flexible metadata
+    has been released in Hyku. %>
+<%# TODO: Delete this file when flexible metadata is released in Hyku %>
+<%= f.input :resource_type, as: :multi_value, input_html: { rows: '14' }, required: f.object.required?(key) %>


### PR DESCRIPTION
Ref:
#318 

Since values have been imported that aren't included in Hyku's default :resource_type values, we're rendering the input as text instead of a select. This way, a work that was imported can still be edited/saved without having to select a default Hyku value. 

![image](https://github.com/user-attachments/assets/b61dac79-5618-4afb-a2c6-44c6c7f3941f)
