### PR TITLE
Disable rack-attack 😢 

### DIFF
--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -142,6 +142,8 @@ extraEnvVars: &envVars
     value: /app/fits/fits.sh
   - name: HYRAX_VALKYRIE
     value: "true"
+  - name: HYKU_ATTACK_RATE_THROTTLE_OFF
+    value: "true"
   - name: HYKU_BULKRAX_ENABLED
     value: "true"
   - name: HYKU_BLOCK_VALKYRIE_REDIRECT

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -125,6 +125,8 @@ extraEnvVars: &envVars
     value: 'false'
   - name: HYKU_ALLOW_SIGNUP
     value: 'false'
+  - name: HYKU_ATTACK_RATE_THROTTLE_OFF
+    value: "true"
   - name: HYKU_BULKRAX_ENABLED
     value: 'true'
   - name: HYKU_BLOCK_VALKYRIE_REDIRECT


### PR DESCRIPTION
It appears that some bot traffic (at least google's) is still referencing the Load Balancer's IP address in the request. We don't want to throttle the LBs, so we're disabling rack-attack until we figure out how to get the real IP addresses for all requests