### PR TITLE
Add site verification header for Google search console

### DIFF
--- a/app/views/layouts/hyku_knapsack/application.html.erb
+++ b/app/views/layouts/hyku_knapsack/application.html.erb
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>Hyku knap sack</title>
+  <meta name="google-site-verification" content=<%="#{ENV['GOOGLE_SITE_VERIFICATION_ID']}"=> />
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
 

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -99,6 +99,8 @@ extraEnvVars: &envVars
     value: http://fcrepo.fcrepo.svc.cluster.local:8080/rest
   - name: HYRAX_ANALYTICS
     value: 'false'
+  - name: GOOGLE_SITE_VERIFICATION_ID
+    value: vLTXyX8EOD-zkakikW8AZhxbdwgexc8WpDIEI8NFjhQ
   # - name: GOOGLE_ANALYTICS_ID
   #   value: $GOOGLE_ANALYTICS_ID
   # - name: GOOGLE_OAUTH_APP_NAME


### PR DESCRIPTION
# Story
Adds metadata to site header to application for Google Search Console verification.

Refs #269

# Notes