### PR TITLE
Use ga4 for site ownership verification

### DIFF
--- a/app/views/layouts/hyku_knapsack/application.html.erb
+++ b/app/views/layouts/hyku_knapsack/application.html.erb
@@ -2,7 +2,6 @@
 <html>
 <head>
   <title>Hyku knap sack</title>
-  <meta name="google-site-verification" content=<%="#{ENV['GOOGLE_SITE_VERIFICATION_ID']}"=> />
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
 

--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -137,7 +137,9 @@ extraEnvVars: &envVars
   - name: HYRAX_ACTIVE_JOB_QUEUE
     value: good_job
   - name: HYRAX_ANALYTICS
-    value: "false"
+    value: "true"
+  - name: HYRAX_ANALYTICS_PROVIDER
+    value: "ga4"
   - name: HYRAX_FITS_PATH
     value: /app/fits/fits.sh
   - name: HYRAX_VALKYRIE

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -98,11 +98,11 @@ extraEnvVars: &envVars
   - name: FCREPO_URL
     value: http://fcrepo.fcrepo.svc.cluster.local:8080/rest
   - name: HYRAX_ANALYTICS
-    value: 'false'
-  - name: GOOGLE_SITE_VERIFICATION_ID
-    value: vLTXyX8EOD-zkakikW8AZhxbdwgexc8WpDIEI8NFjhQ
-  # - name: GOOGLE_ANALYTICS_ID
-  #   value: $GOOGLE_ANALYTICS_ID
+    value: 'true'
+  - name: GOOGLE_ANALYTICS_PROVIDER
+    value: 'ga4'
+  - name: GOOGLE_ANALYTICS_ID
+    value: $GOOGLE_ANALYTICS_ID
   # - name: GOOGLE_OAUTH_APP_NAME
   #   value: atla-hyku-production
   # - name: GOOGLE_OAUTH_APP_VERSION


### PR DESCRIPTION
# Story
The application.html.erb does not actually control the header of the site, so the previous approach did not work.

Hyrax has a built-in configuration for ga4 if you configure it / include the environment variables, so trying that in order to verify our ownership of the property for the Google Search Console.

Refs #269

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes