### PR TITLE
Support Identifier facet links with colons

### DIFF
--- a/app/controllers/catalog_controller_decorator.rb
+++ b/app/controllers/catalog_controller_decorator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module CatalogControllerDecorator
+  extend ActiveSupport::Concern
+end
+CatalogController.prepend(CatalogControllerDecorator)
+
+# OVERRIDE: Hyku 6.1 to support linked identifiers which contain a colon
+CatalogController.configure_blacklight do |config|
+  key = 'identifier_tesim'
+  config.index_fields.delete(key)
+  config.add_index_field key, helper_method: :index_field_link, field_name: 'identifier_sim', if: :render_in_tenant?
+end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -9,7 +9,7 @@
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:bibliographic_citation, html_dl: true) %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted, html_dl: true) %>
-<%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_tesim', html_dl: true) %>
+<%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_sim', html_dl: true) %>
 <%= presenter.attribute_to_html(:keyword, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:date_created, render_as: :linked, search_field: 'date_created_tesim', html_dl: true) %>
 <%= presenter.attribute_to_html(:based_near_label, html_dl: true) %>

--- a/app/views/hyrax/unca_works/_attribute_rows.html.erb
+++ b/app/views/hyrax/unca_works/_attribute_rows.html.erb
@@ -6,7 +6,7 @@
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:abstract, html_dl: true) %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted, html_dl: true) %>
-<%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_tesim', html_dl: true) %>
+<%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_sim', html_dl: true) %>
 <%= presenter.attribute_to_html(:keyword, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:date_created, render_as: :linked, search_field: 'date_created_tesim', label: label_for(term: :date_created, record_class: UncaWork), html_dl: true) %>
 <%= presenter.attribute_to_html(:date_published, render_as: :linked, search_field: 'date_published_tesim', label: label_for(term: :date_published, record_class: UncaWork), html_dl: true) %>


### PR DESCRIPTION
# Story

Refs #302 

Mobius identifiers are often of the format `vital:12345`. As colons are not allowed in urls, the search does not correctly resolve when using `identifier_tesim` for the search. However by switching to search `identifier_sim`, we can find the correct item.

# Expected Behavior Before Changes

Clicking on an `identifier` facet link from the catalog search or the item show page did not correctly search for that identifier.

# Expected Behavior After Changes

Clicking on an `identifier` facet link from from the catalog search or the item show page opens a catalog search for that specific identifier.

# Screenshots / Video

<details>
<summary>Video</summary>

[recorded (14).webm](https://github.com/user-attachments/assets/ee65cae5-b4ff-47d3-a1f1-dd9b87134580)

</details>

# Notes