### PR TITLE
build-submodule-sha-versus-latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Get the commit hash from the hyrax-webapp submodule
+# Get the commit sha from the hyrax-webapp submodule
 ARG BASE_TAG=315925a4
 FROM ghcr.io/samvera/hyku/base:${BASE_TAG} AS hyku-knap-base
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Get the commit sha from the hyrax-webapp submodule
+# This is the SHA of the submodule
 ARG BASE_TAG=315925a4
 FROM ghcr.io/samvera/hyku/base:${BASE_TAG} AS hyku-knap-base
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ghcr.io/samvera/hyku/base:latest AS hyku-knap-base
+# Get the commit hash from the hyrax-webapp submodule
+ARG BASE_TAG=315925a4
+FROM ghcr.io/samvera/hyku/base:${BASE_TAG} AS hyku-knap-base
 
 # This is specifically NOT $APP_PATH but the parent directory
 COPY --chown=1001:101 . /app/samvera


### PR DESCRIPTION
Story
Pin the submodule SHA in the Knapsack base image instead of using the latest tag to avoid Ghostscript-related errors. This resolves compatibility issues with an older version of Hyku that does not build Ghostscript by default.

Expected Behavior Before Changes
The createDerivatives job fails with Ghostscript (gs) errors due to mismatched or missing dependencies in the base image.

Expected Behavior After Changes
The createDerivatives job completes successfully without Ghostscript errors, and all derivatives are generated as expected.