### PR TITLE
Update Sentry config

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -5,7 +5,7 @@ require 'sentry-sidekiq'
 
 Sentry.init do |config|
   config.dsn = ENV['SENTRY_DSN']
-  config.breadcrumbs_logger = [:active_support_logger, :http_logger, :sentry_logger]
+  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
   config.enabled_environments = %w[hykuup-knapsack-friends hykuup-knapsack-production]
   config.debug = true
 end


### PR DESCRIPTION
# Story

Refs: 
- https://github.com/notch8/palni-palci/issues/1076
- https://github.com/notch8/hykuup_knapsack/issues/351

The [sentry logger change](https://github.com/getsentry/sentry-ruby/blob/d3b887f0b3b753eeb99d8ce083a74555808b7a88/CHANGELOG.md) may have caused the jobs spiral we encountered last week. Making the change to hopefully prevent the situation from happening again.
