### PR TITLE
add-admin-tenant-main

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -122,7 +122,7 @@ extraEnvVars: &envVars
   - name: HYRAX_VALKYRIE
     value: "true"
   - name: HYKU_ADMIN_HOST
-    value: admin.hykuup.com
+    value: main.hykuup.com
   - name: HYKU_ADMIN_ONLY_TENANT_CREATION
     value: 'false'
   - name: HYKU_ALLOW_SIGNUP
@@ -148,9 +148,9 @@ extraEnvVars: &envVars
   - name: HYKU_ROOT_HOST
     value: hykuup.com
   - name: INITIAL_ADMIN_EMAIL
-    value: rob@scientist.com
+    value: $INITIAL_ADMIN_EMAIL
   - name: INITIAL_ADMIN_PASSWORD
-    value: testing123
+    value: $INITIAL_ADMIN_PASSWORD
   - name: HYRAX_USE_SOLR_GRAPH_NESTING
     value: "true"
   - name: IN_DOCKER


### PR DESCRIPTION
Cannot create a tenant called admin as it is excluded: https://github.com/samvera/hyku/blob/4ac9b80602b1ca34083396ba43deb943f68be8e1/app/models/concerns/account_cname.rb#L10-L12

Created and configured live on the hykuUp production, committing for persistence in the next deployment.

ENV Vars added to the produciton environment in github for use with deployment in setting the `INITIAL_ADMIN_EMAIL` to the support@notch8.com user with the corresponding  `INITIAL_ADMIN_PASSWORD`, located in 1Password: https://start.1password.com/open/i?a=KGDIV7IWMFDTVIQ5QGJYAWQ2KA&v=4q2d22p6y5ucxb7jpni5xqxeeq&i=rmhkjkm5mvgkro4otm5cvhrjri&h=my.1password.com
