### PR TITLE
update-aws-ses-access-keys

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -198,7 +198,7 @@ extraEnvVars: &envVars
   - name: SMTP_TYPE
     value: login
   - name: SMTP_USER_NAME
-    value: AKIAJUV5DOPWWUKISN3Q
+    value: AKIAJCBUYVAVUEJIDQEA
   - name: SOLR_ADMIN_PASSWORD
     value: $SOLR_ADMIN_PASSWORD
   - name: SOLR_ADMIN_USER


### PR DESCRIPTION
Update to add the ses aws access key that corresponds to the active ses acct
https://start.1password.com/open/i?a=KGDIV7IWMFDTVIQ5QGJYAWQ2KA&v=4q2d22p6y5ucxb7jpni5xqxeeq&i=ltdksabhzn4uawkgaaaygdxlei&h=my.1password.com

# Story
Clients were not able to successfully send outbound mail

After reviewing the creds, saw they were not connected to the current notch8 ses acct.
This persists the updated aws ses access keys and updated the password in github env production for SMTP_PASSWORD