### PR TITLE
Prod deploy 7 15 25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,9 @@ FROM ghcr.io/samvera/hyku/base:${BASE_TAG} AS hyku-knap-base
 
 # This is specifically NOT $APP_PATH but the parent directory
 COPY --chown=1001:101 . /app/samvera
-COPY --chown=1001:101 bundler.d/ /app/.bundler.d/
+RUN ln -s /app/samvera/bundler.d /app/.bundler.d
 ENV BUNDLE_LOCAL__HYKU_KNAPSACK=/app/samvera
 ENV BUNDLE_DISABLE_LOCAL_BRANCH_CHECK=true
-ENV BUNDLE_BUNDLER_INJECT__GEM_PATH=/app/samvera/bundler.d
 
 RUN bundle install --jobs "$(nproc)"
 

--- a/bundler.d/example.rb
+++ b/bundler.d/example.rb
@@ -9,3 +9,7 @@
 gem "sentry-ruby"
 gem "sentry-rails"
 gem "sentry-sidekiq"
+
+override_gem "hyrax",
+             github: "samvera/hyrax",
+             ref: "d6330a1c048bd498da852325a502f8dba0467c11"

--- a/ops/argo-deploy.tmpl.yaml
+++ b/ops/argo-deploy.tmpl.yaml
@@ -73,8 +73,6 @@ extraEnvVars: &envVars
     value: /app/samvera
   - name: BUNDLE_DISABLE_LOCAL_BRANCH_CHECK
     value: "true"
-  - name: BUNDLE_BUNDLER_INJECT__GEM_PATH
-    value: /app/samvera/bundler.d
   - name: CONFDIR
     value: "/app/samvera/hyrax-webapp/solr/conf"
   - name: CLIENT_ADMIN_USER_EMAIL

--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -72,8 +72,6 @@ extraEnvVars: &envVars
     value: /app/samvera
   - name: BUNDLE_DISABLE_LOCAL_BRANCH_CHECK
     value: "true"
-  - name: BUNDLE_BUNDLER_INJECT__GEM_PATH
-    value: /app/samvera/bundler.d
   - name: CONFDIR
     value: "/app/samvera/hyrax-webapp/solr/conf"
   - name: CLIENT_ADMIN_USER_EMAIL
@@ -142,6 +140,8 @@ extraEnvVars: &envVars
     value: "ga4"
   - name: HYRAX_FITS_PATH
     value: /app/fits/fits.sh
+  - name: HYRAX_FLEXIBLE
+    value: "true"
   - name: HYRAX_VALKYRIE
     value: "true"
   - name: HYKU_ATTACK_RATE_THROTTLE_OFF

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -67,8 +67,6 @@ extraEnvVars: &envVars
     value: /app/samvera
   - name: BUNDLE_DISABLE_LOCAL_BRANCH_CHECK
     value: "true"
-  - name: BUNDLE_BUNDLER_INJECT__GEM_PATH
-    value: /app/samvera/bundler.d
   - name: CONFDIR
     value: "/app/samvera/hyrax-webapp/solr/conf"
   - name: DB_ADAPTER

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -72,8 +72,6 @@ extraEnvVars: &envVars
     value: /app/samvera
   - name: BUNDLE_DISABLE_LOCAL_BRANCH_CHECK
     value: "true"
-  - name: BUNDLE_BUNDLER_INJECT__GEM_PATH
-    value: /app/samvera/bundler.d
   - name: CONFDIR
     value: "/app/samvera/hyrax-webapp/solr/conf"
   - name: CLIENT_ADMIN_USER_EMAIL


### PR DESCRIPTION
## DEPLOY PROD 07-15-2025

1a58781e17a7eae50da48a6bd841db71a2735fff

This allows hyku version to remain at 315925a4 while pulling in the fix for chunk uploads by pinning the hyrax version in bundler.d/example

## Fix bundler inject

3448d60ae6d1046d354d0c7c1ce2df2bf6263435

Symlink bundler.d directory and stop trying to make BUNDLE_BUNDLER_INJECT__GEM_PATH happen.

ref:

Fix bundler inject palni_palci_knapsack#120
