### PR TITLE
Update hyrax for follow up chunk upload fix

### DIFF
--- a/bundler.d/example.rb
+++ b/bundler.d/example.rb
@@ -12,4 +12,4 @@ gem "sentry-sidekiq"
 
 override_gem "hyrax",
              github: "samvera/hyrax",
-             ref: "d6330a1c048bd498da852325a502f8dba0467c11"
+             ref: "ab4d108114289822b186579cd73a53d68c145a73"


### PR DESCRIPTION
Original PR - https://github.com/notch8/hykuup_knapsack/pull/395

Follow up version bump is needed due to subsequent changes in hyrax. allows submodule to stay at 315925a4