### PR TITLE
update-submodule-hyku-ac07ef6a

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This is the SHA of the submodule
-ARG BASE_TAG=5fd3380c
+ARG BASE_TAG=ac07ef6a
 
 FROM ghcr.io/samvera/hyku/base:${BASE_TAG} AS hyku-knap-base
 # This is specifically NOT $APP_PATH but the parent directory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,9 +74,19 @@ services:
       service: db
 
   base:
+    <<: *app
     extends:
       file: hyrax-webapp/docker-compose.yml
       service: base
+    build:
+      context: .
+      target: hyku-knap-base
+      cache_from:
+        - ghcr.io/samvera/hyku/base:latest
+      args:
+        BUILDKIT_INLINE_CACHE: 1
+        APP_PATH: ./hyrax-webapp
+        BASE_TAG: ${BASE_TAG:-latest}
     image: ghcr.io/samvera/hyku/base:${BASE_TAG:-latest}
     command: bash -l -c "echo 'base is only used for building base images, which in turn reduces image build times. It does not need to be run'"
 


### PR DESCRIPTION
Update pin to use fresh off main hyku sha for submodule and update base to actually build the base_tag we are passing in the Dockerfile

# Story
Update hyku submodule to sha ac07ef6a, the bug change is that is where the change was made for pinning a version of the forked willow_sword gem which was causing hardlink issues when building the image and bundling in ci
