### PR TITLE
🎁 Exclude collection from catalog search results

### DIFF
--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -2045,3 +2045,31 @@ properties:
     view:
       render_as: "faceted"
       html_dl: true
+  hide_from_catalog_search:
+    available_on:
+      class:
+        - CollectionResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#bool
+      sources:
+        - "null"
+    display_label:
+      default: Hide from Catalog Search
+    index_documentation: displayable, searchable
+    indexing:
+      - hide_from_catalog_search_bsi
+      - hide_from_catalog_search_tesim
+    form:
+      display: false
+      primary: false
+      required: false
+      multiple: false
+    property_uri: https://hykucommons.org/terms/hide_from_catalog_search
+    range: http://www.w3.org/2001/XMLSchema#bool
+    sample_values:
+      - true
+      - false


### PR DESCRIPTION
This commit updates the metadata profile to add the ability to exclude a collection from the catalog search results via the `hide_from_catalog_search` attribute which is added to the collection resource metadata.

Ref:
- https://github.com/notch8/adventist_knapsack/issues/892