### PR TITLE
:bug: hotfix: set default locale

### DIFF
--- a/app/controllers/application_controller_decorator.rb
+++ b/app/controllers/application_controller_decorator.rb
@@ -11,7 +11,9 @@ module ApplicationControllerDecorator
 
   def set_locale_from_params
     # Set locale from params or fall back to default
-    I18n.locale = params[:locale] || I18n.default_locale
+    # Handle both nil and empty string cases
+    locale = params[:locale].presence || I18n.default_locale
+    I18n.locale = locale
   end
 
   def default_url_options

--- a/app/controllers/application_controller_decorator.rb
+++ b/app/controllers/application_controller_decorator.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module ApplicationControllerDecorator
+  extend ActiveSupport::Concern
+
+  included do
+    prepend_before_action :set_locale_from_params
+  end
+
+  private
+
+  def set_locale_from_params
+    # Set locale from params or fall back to default
+    I18n.locale = params[:locale] || I18n.default_locale
+  end
+
+  def default_url_options
+    # Ensure all generated URLs include the current locale
+    super.merge(locale: I18n.locale)
+  end
+end
+
+ApplicationController.include(ApplicationControllerDecorator)


### PR DESCRIPTION
When users type in a url without the locale, it causes the site to crash.

https://demo.hykuup.com/ vs https://demo.hykuup.com/?locale=en

Issue: 
- https://github.com/notch8/dev-ops/issues/978#issuecomment-3304527088