### PR TITLE
🐛 Fix UV small image download route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,19 @@
 # frozen_string_literal: true
 HykuKnapsack::Engine.routes.draw do
 end
+
+Rails.application.routes.draw do
+  # TODO: this route is a temporary fix for UV small image download not working
+  get '/:file_path/full/:size/:rotation/:quality.:format',
+    to: redirect { |params|
+      encoded_path = params[:file_path].gsub('/', '%2F')
+      "/images/#{encoded_path}/full/#{params[:size]}/#{params[:rotation]}/#{params[:quality]}.#{params[:format]}"
+    },
+    constraints: {
+      file_path: /[a-f0-9-]+%2Ffiles%2F[a-f0-9-]+/,
+      size: /[\d,!]+/,
+      rotation: /\d+/,
+      quality: /\w+/,
+      format: /(jpg|png|gif|webp)/
+    }
+end


### PR DESCRIPTION
This commit will add a workaround for the small image download option in the Universal Viewer by intercepting the request and redirecting it to the appropriate route.

Ref:
- https://github.com/notch8/hykuup_knapsack/issues/276

![mobius-uv](https://github.com/user-attachments/assets/f327f772-ceeb-481d-864b-a545eccb5a8c)
