### PR TITLE
I524 load default profile by tenant cname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ file_cache/
 .byebug_history
 
 Gemfile.lock
+/.cache

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 inherit_gem:
   bixby: bixby_default.yml
 
+Layout/IndentationWidth:
+  Width: 2
+
 AllCops:
   NewCops: disable
   TargetRubyVersion: 3.2.2
@@ -9,9 +12,10 @@ AllCops:
   # NOTE: When we run knapsack's rubocop, we don't want to check the submodule
   #       for Hyku.  We'll assume it's okay and has it's own policing policies.
   - "hyrax-webapp/**/*"
+  - "gems/**/*"
 
 Metrics/BlockLength:
-  IgnoredMethods: ['included', 'describe', 'it', 'context']
+  AllowedMethods: ['included', 'describe', 'it', 'context']
   Exclude:
   - "spec/**/*.rb"
 

--- a/app/controllers/admin/work_types_controller_decorator.rb
+++ b/app/controllers/admin/work_types_controller_decorator.rb
@@ -16,7 +16,7 @@ module Admin
 
       profile_classes = profile['classes']&.keys || []
       profile_work_types = profile_classes.map { |klass| klass.gsub(/Resource$/, '') }
-      
+
       # Apply tenant-specific filtering to hide work types tenants don't "own"
       tenant_allowed_types = TenantWorkTypeFilter.allowed_work_types
       @profile_work_types = profile_work_types & tenant_allowed_types & Hyrax.config.registered_curation_concern_types
@@ -31,7 +31,7 @@ module Admin
 
       profile_classes = profile['classes']&.keys || []
       profile_work_types = profile_classes.map { |klass| klass.gsub(/Resource$/, '') }
-      
+
       # Apply tenant-specific filtering
       tenant_allowed_types = TenantWorkTypeFilter.allowed_work_types
       allowed_work_types = profile_work_types & tenant_allowed_types & Hyrax.config.registered_curation_concern_types

--- a/app/controllers/admin/work_types_controller_decorator.rb
+++ b/app/controllers/admin/work_types_controller_decorator.rb
@@ -18,7 +18,7 @@ module Admin
       profile_work_types = profile_classes.map { |klass| klass.gsub(/Resource$/, '') }
       
       # Apply tenant-specific filtering to hide work types tenants don't "own"
-      tenant_allowed_types = tenant_allowed_work_types
+      tenant_allowed_types = TenantWorkTypeFilter.allowed_work_types
       @profile_work_types = profile_work_types & tenant_allowed_types & Hyrax.config.registered_curation_concern_types
     end
 
@@ -33,42 +33,10 @@ module Admin
       profile_work_types = profile_classes.map { |klass| klass.gsub(/Resource$/, '') }
       
       # Apply tenant-specific filtering
-      tenant_allowed_types = tenant_allowed_work_types
+      tenant_allowed_types = TenantWorkTypeFilter.allowed_work_types
       allowed_work_types = profile_work_types & tenant_allowed_types & Hyrax.config.registered_curation_concern_types
 
       available_works & allowed_work_types
-    end
-
-    # Returns only work types that the current tenant is allowed to see
-    def tenant_allowed_work_types
-      all_work_types = Hyrax.config.registered_curation_concern_types
-      excluded_work_types = tenant_excluded_work_types
-      
-      all_work_types - excluded_work_types
-    end
-
-    # Returns work types that should be excluded for the current tenant
-    def tenant_excluded_work_types
-      case current_tenant_cname
-      when 'unca.hykuup.com'
-        # UNCA cannot see: MobiusWork
-        %w[MobiusWork]
-      when /\.digitalmobius\.org$/
-        # Mobius cannot see: UncaWork, ScholarlyWork
-        %w[UncaWork ScholarlyWork]
-      else
-        # Generic tenants cannot see: MobiusWork, UncaWork, ScholarlyWork
-        %w[MobiusWork UncaWork ScholarlyWork]
-      end
-    end
-
-    def current_tenant_cname
-      return nil unless defined?(Account)
-      
-      current_tenant = Apartment::Tenant.current
-      return nil unless current_tenant
-      
-      Account.find_by(tenant: current_tenant)&.cname
     end
   end
 end

--- a/app/controllers/admin/work_types_controller_decorator.rb
+++ b/app/controllers/admin/work_types_controller_decorator.rb
@@ -41,19 +41,24 @@ module Admin
 
     # Returns only work types that the current tenant is allowed to see
     def tenant_allowed_work_types
+      all_work_types = Hyrax.config.registered_curation_concern_types
+      excluded_work_types = tenant_excluded_work_types
+      
+      all_work_types - excluded_work_types
+    end
+
+    # Returns work types that should be excluded for the current tenant
+    def tenant_excluded_work_types
       case current_tenant_cname
       when 'unca.hykuup.com'
-        # UNCA can see: GenericWork, Image, OER, ETD, ScholarlyWork, UncaWork
         # UNCA cannot see: MobiusWork
-        %w[GenericWork Image Oer Etd ScholarlyWork UncaWork]
+        %w[MobiusWork]
       when /\.digitalmobius\.org$/
-        # Mobius can see: GenericWork, Image, OER, ETD, MobiusWork
         # Mobius cannot see: UncaWork, ScholarlyWork
-        %w[GenericWork Image Oer Etd MobiusWork]
+        %w[UncaWork ScholarlyWork]
       else
-        # Generic tenants can see: GenericWork, Image, OER, ETD
         # Generic tenants cannot see: MobiusWork, UncaWork, ScholarlyWork
-        %w[GenericWork Image Oer Etd]
+        %w[MobiusWork UncaWork ScholarlyWork]
       end
     end
 

--- a/app/controllers/admin/work_types_controller_decorator.rb
+++ b/app/controllers/admin/work_types_controller_decorator.rb
@@ -7,36 +7,32 @@ module Admin
 
     private
 
-    # OVERRIDE: Filter work types based on tenant ownership
+    # OVERRIDE: Filter work types based on tenant-specific visibility rules
     def setup_profile_work_types
-      return unless Hyrax.config.flexible?
-
-      profile = Hyrax::FlexibleSchema.current_version
-      return unless profile
-
-      profile_classes = profile['classes']&.keys || []
-      profile_work_types = profile_classes.map { |klass| klass.gsub(/Resource$/, '') }
-
-      # Apply tenant-specific filtering to hide work types tenants don't "own"
-      tenant_allowed_types = TenantWorkTypeFilter.allowed_work_types
-      @profile_work_types = profile_work_types & tenant_allowed_types & Hyrax.config.registered_curation_concern_types
+      @profile_work_types = allowed_work_types_for_profile
     end
 
     # OVERRIDE: Filter by profile with tenant awareness
     def filter_by_profile(available_works)
-      return available_works unless Hyrax.config.flexible?
+      allowed_types = allowed_work_types_for_profile
+      return available_works if allowed_types.empty?
+
+      available_works & allowed_types
+    end
+
+    # Extract common logic for determining allowed work types based on profile and tenant
+    def allowed_work_types_for_profile
+      return [] unless Hyrax.config.flexible?
 
       profile = Hyrax::FlexibleSchema.current_version
-      return available_works unless profile
+      return [] unless profile
 
       profile_classes = profile['classes']&.keys || []
       profile_work_types = profile_classes.map { |klass| klass.gsub(/Resource$/, '') }
 
-      # Apply tenant-specific filtering
+      # Apply tenant-specific filtering to restrict work type visibility
       tenant_allowed_types = TenantWorkTypeFilter.allowed_work_types
-      allowed_work_types = profile_work_types & tenant_allowed_types & Hyrax.config.registered_curation_concern_types
-
-      available_works & allowed_work_types
+      profile_work_types & tenant_allowed_types & Hyrax.config.registered_curation_concern_types
     end
   end
 end

--- a/app/controllers/admin/work_types_controller_decorator.rb
+++ b/app/controllers/admin/work_types_controller_decorator.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyku v6.2.0: Hide work types completely based on tenant instead of graying them out
+module Admin
+  module WorkTypesControllerDecorator
+    extend ActiveSupport::Concern
+
+    private
+
+    # OVERRIDE: Filter work types based on tenant ownership
+    def setup_profile_work_types
+      return unless Hyrax.config.flexible?
+
+      profile = Hyrax::FlexibleSchema.current_version
+      return unless profile
+
+      profile_classes = profile['classes']&.keys || []
+      profile_work_types = profile_classes.map { |klass| klass.gsub(/Resource$/, '') }
+      
+      # Apply tenant-specific filtering to hide work types tenants don't "own"
+      tenant_allowed_types = tenant_allowed_work_types
+      @profile_work_types = profile_work_types & tenant_allowed_types & Hyrax.config.registered_curation_concern_types
+    end
+
+    # OVERRIDE: Filter by profile with tenant awareness
+    def filter_by_profile(available_works)
+      return available_works unless Hyrax.config.flexible?
+
+      profile = Hyrax::FlexibleSchema.current_version
+      return available_works unless profile
+
+      profile_classes = profile['classes']&.keys || []
+      profile_work_types = profile_classes.map { |klass| klass.gsub(/Resource$/, '') }
+      
+      # Apply tenant-specific filtering
+      tenant_allowed_types = tenant_allowed_work_types
+      allowed_work_types = profile_work_types & tenant_allowed_types & Hyrax.config.registered_curation_concern_types
+
+      available_works & allowed_work_types
+    end
+
+    # Returns only work types that the current tenant is allowed to see
+    def tenant_allowed_work_types
+      case current_tenant_cname
+      when 'unca.hykuup.com'
+        # UNCA can see: GenericWork, Image, OER, ETD, ScholarlyWork, UncaWork
+        # UNCA cannot see: MobiusWork
+        %w[GenericWork Image Oer Etd ScholarlyWork UncaWork]
+      when /\.digitalmobius\.org$/
+        # Mobius can see: GenericWork, Image, OER, ETD, MobiusWork
+        # Mobius cannot see: UncaWork, ScholarlyWork
+        %w[GenericWork Image Oer Etd MobiusWork]
+      else
+        # Generic tenants can see: GenericWork, Image, OER, ETD
+        # Generic tenants cannot see: MobiusWork, UncaWork, ScholarlyWork
+        %w[GenericWork Image Oer Etd]
+      end
+    end
+
+    def current_tenant_cname
+      return nil unless defined?(Account)
+      
+      current_tenant = Apartment::Tenant.current
+      return nil unless current_tenant
+      
+      Account.find_by(tenant: current_tenant)&.cname
+    end
+  end
+end
+
+Admin::WorkTypesController.prepend(Admin::WorkTypesControllerDecorator)

--- a/app/controllers/hyrax/metadata_profiles_controller_decorator.rb
+++ b/app/controllers/hyrax/metadata_profiles_controller_decorator.rb
@@ -8,19 +8,16 @@ module Hyrax
     private
 
     # OVERRIDE: Add tenant-specific validation before creating the profile
+    # rubocop:disable Metrics/MethodLength
     def import
-      uploaded_io = params[:file]
-      if uploaded_io.blank?
-        redirect_to metadata_profiles_path, alert: 'Please select a file to upload'
-        return
-      end
+      return redirect_to_index_with_alert unless uploaded_file_present?
 
       begin
-        profile_data = YAML.safe_load_file(uploaded_io.path)
-        
+        profile_data = YAML.safe_load_file(params[:file].path)
+
         # Validate that the profile doesn't contain work types the tenant doesn't "own"
         validate_tenant_work_types!(profile_data)
-        
+
         @flexible_schema = Hyrax::FlexibleSchema.create(profile: profile_data)
 
         if @flexible_schema.persisted?
@@ -34,26 +31,34 @@ module Hyrax
         nil
       end
     end
+    # rubocop:enable Metrics/MethodLength
+
+    def uploaded_file_present?
+      params[:file].present?
+    end
+
+    def redirect_to_index_with_alert
+      redirect_to metadata_profiles_path, alert: 'Please select a file to upload'
+    end
 
     # Validates that the profile doesn't contain work types the current tenant doesn't "own"
     def validate_tenant_work_types!(profile_data)
       return unless profile_data&.dig('classes')
-      
+
       profile_work_types = extract_profile_work_types(profile_data)
       excluded_work_types = TenantWorkTypeFilter.excluded_work_types
-      
+
       # Check if the profile contains any work types this tenant shouldn't see
       forbidden_work_types = profile_work_types & excluded_work_types
-      
-      if forbidden_work_types.any?
-        tenant_name = TenantWorkTypeFilter.current_tenant_cname || 'this tenant'
-        allowed_work_types = TenantWorkTypeFilter.allowed_work_types
-        
-        raise StandardError, 
-              "This profile contains work types (#{forbidden_work_types.join(', ')}) that are not allowed for #{tenant_name}. " \
-              "Please use a profile that only contains work types appropriate for your tenant. " \
-              "Allowed work types for #{tenant_name}: #{allowed_work_types.join(', ')}."
-      end
+
+      return unless forbidden_work_types.any?
+      tenant_name = TenantWorkTypeFilter.current_tenant_cname || 'this tenant'
+      allowed_work_types = TenantWorkTypeFilter.allowed_work_types
+
+      raise StandardError,
+            "This profile contains work types (#{forbidden_work_types.join(', ')}) that are not allowed for #{tenant_name}. " \
+            "Please use a profile that only contains work types appropriate for your tenant. " \
+            "Allowed work types for #{tenant_name}: #{allowed_work_types.join(', ')}."
     end
 
     def extract_profile_work_types(profile_data)

--- a/app/controllers/hyrax/metadata_profiles_controller_decorator.rb
+++ b/app/controllers/hyrax/metadata_profiles_controller_decorator.rb
@@ -47,9 +47,12 @@ module Hyrax
       
       if forbidden_work_types.any?
         tenant_name = current_tenant_cname || 'this tenant'
+        allowed_work_types = tenant_allowed_work_types
+        
         raise StandardError, 
               "This profile contains work types (#{forbidden_work_types.join(', ')}) that are not allowed for #{tenant_name}. " \
-              "Please use a profile that only contains work types appropriate for your tenant."
+              "Please use a profile that only contains work types appropriate for your tenant. " \
+              "Allowed work types for #{tenant_name}: #{allowed_work_types.join(', ')}."
       end
     end
 
@@ -71,6 +74,14 @@ module Hyrax
         # Generic tenants cannot see: MobiusWork, UncaWork, ScholarlyWork
         %w[MobiusWork UncaWork ScholarlyWork]
       end
+    end
+
+    # Returns work types that the current tenant is allowed to use
+    def tenant_allowed_work_types
+      all_work_types = Hyrax.config.registered_curation_concern_types
+      excluded_work_types = tenant_excluded_work_types
+      
+      all_work_types - excluded_work_types
     end
 
     def current_tenant_cname

--- a/app/controllers/hyrax/metadata_profiles_controller_decorator.rb
+++ b/app/controllers/hyrax/metadata_profiles_controller_decorator.rb
@@ -15,7 +15,7 @@ module Hyrax
       begin
         profile_data = YAML.safe_load_file(params[:file].path)
 
-        # Validate that the profile doesn't contain work types the tenant doesn't "own"
+        # Validate that the profile doesn't contain work types restricted for this tenant
         validate_tenant_work_types!(profile_data)
 
         @flexible_schema = Hyrax::FlexibleSchema.create(profile: profile_data)
@@ -41,7 +41,7 @@ module Hyrax
       redirect_to metadata_profiles_path, alert: 'Please select a file to upload'
     end
 
-    # Validates that the profile doesn't contain work types the current tenant doesn't "own"
+    # Validates that the profile doesn't contain work types restricted for the current tenant
     def validate_tenant_work_types!(profile_data)
       return unless profile_data&.dig('classes')
 

--- a/app/services/hyrax/quick_classification_query_decorator.rb
+++ b/app/services/hyrax/quick_classification_query_decorator.rb
@@ -24,39 +24,12 @@ module Hyrax
     # Returns work types that the current tenant is allowed to create
     def tenant_filtered_work_types
       begin
-        all_work_types = Hyrax.config.registered_curation_concern_types
-        excluded_work_types = tenant_excluded_work_types
-        
-        all_work_types - excluded_work_types
+        TenantWorkTypeFilter.allowed_work_types
       rescue => e
         Rails.logger.warn "Error in tenant filtering: #{e.message}"
         # Fallback to all registered work types if filtering fails
         Hyrax.config.registered_curation_concern_types
       end
-    end
-
-    # Returns work types that should be excluded for the current tenant
-    def tenant_excluded_work_types
-      case current_tenant_cname
-      when 'unca.hykuup.com'
-        # UNCA cannot see: MobiusWork
-        %w[MobiusWork]
-      when /\.digitalmobius\.org$/
-        # Mobius cannot see: UncaWork, ScholarlyWork
-        %w[UncaWork ScholarlyWork]
-      else
-        # Generic tenants cannot see: MobiusWork, UncaWork, ScholarlyWork
-        %w[MobiusWork UncaWork ScholarlyWork]
-      end
-    end
-
-    def current_tenant_cname
-      return nil unless defined?(Account)
-      
-      current_tenant = Apartment::Tenant.current
-      return nil unless current_tenant
-      
-      Account.find_by(tenant: current_tenant)&.cname
     end
   end
 end

--- a/app/services/hyrax/quick_classification_query_decorator.rb
+++ b/app/services/hyrax/quick_classification_query_decorator.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyku v6.2.0: Apply tenant-specific work type filtering to work creation
+module Hyrax
+  module QuickClassificationQueryDecorator
+    extend ActiveSupport::Concern
+
+    # OVERRIDE: Apply tenant-specific filtering to work types available for creation
+    def authorized_models
+      original_models = super
+      
+      filtered_models = tenant_filtered_work_types
+      
+      original_models.select { |model| filtered_models.include?(model.name) }
+    end
+
+    # OVERRIDE: Check if all tenant-allowed work types are available
+    def all?
+      models == tenant_filtered_work_types
+    end
+
+    private
+
+    # Returns work types that the current tenant is allowed to create
+    def tenant_filtered_work_types
+      begin
+        all_work_types = Hyrax.config.registered_curation_concern_types
+        excluded_work_types = tenant_excluded_work_types
+        
+        all_work_types - excluded_work_types
+      rescue => e
+        Rails.logger.warn "Error in tenant filtering: #{e.message}"
+        # Fallback to all registered work types if filtering fails
+        Hyrax.config.registered_curation_concern_types
+      end
+    end
+
+    # Returns work types that should be excluded for the current tenant
+    def tenant_excluded_work_types
+      case current_tenant_cname
+      when 'unca.hykuup.com'
+        # UNCA cannot see: MobiusWork
+        %w[MobiusWork]
+      when /\.digitalmobius\.org$/
+        # Mobius cannot see: UncaWork, ScholarlyWork
+        %w[UncaWork ScholarlyWork]
+      else
+        # Generic tenants cannot see: MobiusWork, UncaWork, ScholarlyWork
+        %w[MobiusWork UncaWork ScholarlyWork]
+      end
+    end
+
+    def current_tenant_cname
+      return nil unless defined?(Account)
+      
+      current_tenant = Apartment::Tenant.current
+      return nil unless current_tenant
+      
+      Account.find_by(tenant: current_tenant)&.cname
+    end
+  end
+end
+
+Hyrax::QuickClassificationQuery.prepend(Hyrax::QuickClassificationQueryDecorator)

--- a/app/services/hyrax/quick_classification_query_decorator.rb
+++ b/app/services/hyrax/quick_classification_query_decorator.rb
@@ -8,9 +8,9 @@ module Hyrax
     # OVERRIDE: Apply tenant-specific filtering to work types available for creation
     def authorized_models
       original_models = super
-      
+
       filtered_models = tenant_filtered_work_types
-      
+
       original_models.select { |model| filtered_models.include?(model.name) }
     end
 
@@ -23,13 +23,11 @@ module Hyrax
 
     # Returns work types that the current tenant is allowed to create
     def tenant_filtered_work_types
-      begin
-        TenantWorkTypeFilter.allowed_work_types
-      rescue => e
-        Rails.logger.warn "Error in tenant filtering: #{e.message}"
-        # Fallback to all registered work types if filtering fails
-        Hyrax.config.registered_curation_concern_types
-      end
+      TenantWorkTypeFilter.allowed_work_types
+    rescue => e
+      Rails.logger.warn "Error in tenant filtering: #{e.message}"
+      # Fallback to all registered work types if filtering fails
+      Hyrax.config.registered_curation_concern_types
     end
   end
 end

--- a/app/services/tenant_work_type_filter.rb
+++ b/app/services/tenant_work_type_filter.rb
@@ -24,7 +24,7 @@ class TenantWorkTypeFilter
     def allowed_work_types
       all_work_types = Hyrax.config.registered_curation_concern_types
       excluded_work_types = self.excluded_work_types
-      
+
       all_work_types - excluded_work_types
     end
 
@@ -46,10 +46,10 @@ class TenantWorkTypeFilter
     # @return [String, nil] The tenant's cname or nil if not found
     def current_tenant_cname
       return nil unless defined?(Account)
-      
+
       current_tenant = Apartment::Tenant.current
       return nil unless current_tenant
-      
+
       Account.find_by(tenant: current_tenant)&.cname
     end
   end

--- a/app/services/tenant_work_type_filter.rb
+++ b/app/services/tenant_work_type_filter.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Service class for tenant-specific configuration and filtering
+class TenantWorkTypeFilter
+  class << self
+    # Returns work types that should be excluded for the current tenant
+    # @return [Array<String>] Array of work type names to exclude
+    def excluded_work_types
+      case current_tenant_cname
+      when 'unca.hykuup.com'
+        # UNCA cannot see: MobiusWork
+        %w[MobiusWork]
+      when /\.digitalmobius\.org$/
+        # Mobius cannot see: UncaWork, ScholarlyWork
+        %w[UncaWork ScholarlyWork]
+      else
+        # Generic tenants cannot see: MobiusWork, UncaWork, ScholarlyWork
+        %w[MobiusWork UncaWork ScholarlyWork]
+      end
+    end
+
+    # Returns work types that the current tenant is allowed to use
+    # @return [Array<String>] Array of work type names that are allowed
+    def allowed_work_types
+      all_work_types = Hyrax.config.registered_curation_concern_types
+      excluded_work_types = self.excluded_work_types
+      
+      all_work_types - excluded_work_types
+    end
+
+    # Returns the metadata profile path for the current tenant
+    # @param default_path [String] The default profile path to use as fallback
+    # @return [String] Path to the tenant-specific metadata profile
+    def tenant_metadata_profile_path(default_path)
+      case current_tenant_cname
+      when 'unca.hykuup.com'
+        HykuKnapsack::Engine.root.join('config', 'metadata_profiles', 'unca', 'm3_profile.yaml')
+      when /\.digitalmobius\.org$/
+        HykuKnapsack::Engine.root.join('config', 'metadata_profiles', 'mobius', 'm3_profile.yaml')
+      else
+        default_path
+      end
+    end
+
+    # Returns the current tenant's cname
+    # @return [String, nil] The tenant's cname or nil if not found
+    def current_tenant_cname
+      return nil unless defined?(Account)
+      
+      current_tenant = Apartment::Tenant.current
+      return nil unless current_tenant
+      
+      Account.find_by(tenant: current_tenant)&.cname
+    end
+  end
+end

--- a/app/views/admin/work_types/edit.html.erb
+++ b/app/views/admin/work_types/edit.html.erb
@@ -4,7 +4,7 @@
 
 <%
   # OVERRIDE Hyku v6.2.0: Use tenant-filtered work types instead of all registered types
-  tenant_work_types = controller.send(:tenant_allowed_work_types)
+  tenant_work_types = TenantWorkTypeFilter.allowed_work_types
   
   # Check if there are any work types that will be disabled (not in profile)
   has_disabled_work_types = false

--- a/app/views/admin/work_types/edit.html.erb
+++ b/app/views/admin/work_types/edit.html.erb
@@ -1,0 +1,55 @@
+<% provide :page_header do %>
+  <h1><span class="fa fa-address-book"></span> <%= t('hyku.admin.work_types') %></h1>
+<% end %>
+
+<%
+  # OVERRIDE Hyku v6.2.0: Use tenant-filtered work types instead of all registered types
+  tenant_work_types = controller.send(:tenant_allowed_work_types)
+  
+  # Check if there are any work types that will be disabled (not in profile)
+  has_disabled_work_types = false
+  if Hyrax.config.flexible? && @profile_work_types
+    has_disabled_work_types = tenant_work_types.any? do |type|
+      !@profile_work_types.include?(type)
+    end
+  end
+%>
+
+<% if has_disabled_work_types %>
+  <div class="alert alert-info" role="alert">
+    <strong>Note:</strong> Work types grayed out below are not included in the current metadata profile. 
+    To enable them, please add them to your metadata profile first.
+  </div>
+<% end %>
+
+<div class="card">
+  <div class="card-body">
+    <%= simple_form_for @site, url: '/admin/work_types' do |f| %>
+      <% tenant_work_types.each do |type| %>
+        <% 
+          is_in_profile = !Hyrax.config.flexible? || @profile_work_types&.include?(type)
+          is_checked = @site.available_works&.include?(type)
+          is_disabled = Hyrax.config.flexible? && !is_in_profile
+        %>
+        <div class="form-check <%= 'text-muted' if is_disabled %>">
+          <label class="form-check-label" for="input-<%= type %>">
+            <input 
+              class="form-check-input" 
+              type="checkbox" 
+              value="<%= type %>" 
+              id="input-<%= type %>" 
+              name="available_works[]" 
+              <%= 'checked' if is_checked %>
+              <%= 'disabled' if is_disabled %>
+            >
+            <span><%= type %></span>
+            <% if is_disabled %>
+              <small class="text-muted d-block">Not included in metadata profile</small>
+            <% end %>
+          </label>
+        </div>
+      <% end %>
+      <%= f.submit class: 'btn btn-primary' %>
+    <% end %>
+  </div>
+</div>

--- a/bundler.d/example.rb
+++ b/bundler.d/example.rb
@@ -9,3 +9,6 @@
 gem "sentry-ruby"
 gem "sentry-rails"
 gem "sentry-sidekiq"
+
+ensure_gem "rubocop-rake"
+ensure_gem "rubocop-rspec"

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -15,7 +15,7 @@ Rails.application.config.after_initialize do
     config.register_curation_concern :scholarly_work
   end
 
-  # Override the create_default_schema method to load tenant-specific profiles
+  # Override Hyrax v5.0.5: the create_default_schema method to load tenant-specific profiles
   Hyrax::FlexibleSchema.class_eval do
     def self.create_default_schema
       m3_profile_path = tenant_specific_profile_path

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -5,10 +5,51 @@
 Rails.application.config.after_initialize do
   Hyrax.config do |config|
     config.flexible = ActiveModel::Type::Boolean.new.cast(ENV.fetch('HYRAX_FLEXIBLE', false))
-    config.default_m3_profile_path = HykuKnapsack::Engine.root.join('config', 'metadata_profiles', 'm3_profile.yaml')
+    
+    # Set default profile path (fallback)
+    config.default_m3_profile_path = HykuKnapsack::Engine.root.join('config', 'metadata_profiles', 'default', 'm3_profile.yaml')
 
     config.register_curation_concern :mobius_work
     config.register_curation_concern :unca_work
     config.register_curation_concern :scholarly_work
+  end
+
+  # Override the create_default_schema method to load tenant-specific profiles
+  Hyrax::FlexibleSchema.class_eval do
+    def self.create_default_schema
+      m3_profile_path = tenant_specific_profile_path
+      
+      # Clear existing profiles to ensure we load the correct tenant-specific one
+      Hyrax::FlexibleSchema.destroy_all
+      
+      Hyrax::FlexibleSchema.create do |f|
+        f.profile = YAML.safe_load_file(m3_profile_path)
+      end
+    end
+
+    private
+
+    def self.tenant_specific_profile_path
+      return default_profile_path unless defined?(Account)
+      
+      current_tenant = Apartment::Tenant.current
+      return default_profile_path unless current_tenant
+      
+      account = Account.find_by(tenant: current_tenant)
+      return default_profile_path unless account
+      
+      case account.cname
+      when 'unca.hykuup.com'
+        HykuKnapsack::Engine.root.join('config', 'metadata_profiles', 'unca', 'm3_profile.yaml')
+      when /\.digitalmobius\.org$/
+        HykuKnapsack::Engine.root.join('config', 'metadata_profiles', 'mobius', 'm3_profile.yaml')
+      else
+        default_profile_path
+      end
+    end
+
+    def self.default_profile_path
+      Hyrax.config.default_m3_profile_path || Rails.root.join('config', 'metadata_profiles', 'm3_profile.yaml')
+    end
   end
 end

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -38,14 +38,7 @@ Rails.application.config.after_initialize do
       account = Account.find_by(tenant: current_tenant)
       return default_profile_path unless account
       
-      case account.cname
-      when 'unca.hykuup.com'
-        HykuKnapsack::Engine.root.join('config', 'metadata_profiles', 'unca', 'm3_profile.yaml')
-      when /\.digitalmobius\.org$/
-        HykuKnapsack::Engine.root.join('config', 'metadata_profiles', 'mobius', 'm3_profile.yaml')
-      else
-        default_profile_path
-      end
+     TenantWorkTypeFilter.tenant_metadata_profile_path(default_profile_path)
     end
 
     def self.default_profile_path

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -2,10 +2,11 @@
 
 # Use this to override any Hyrax configuration from the Knapsack
 
+# rubocop:disable Metrics/BlockLength
 Rails.application.config.after_initialize do
   Hyrax.config do |config|
     config.flexible = ActiveModel::Type::Boolean.new.cast(ENV.fetch('HYRAX_FLEXIBLE', false))
-    
+
     # Set default profile path (fallback)
     config.default_m3_profile_path = HykuKnapsack::Engine.root.join('config', 'metadata_profiles', 'default', 'm3_profile.yaml')
 
@@ -18,27 +19,25 @@ Rails.application.config.after_initialize do
   Hyrax::FlexibleSchema.class_eval do
     def self.create_default_schema
       m3_profile_path = tenant_specific_profile_path
-      
+
       # Clear existing profiles to ensure we load the correct tenant-specific one
       Hyrax::FlexibleSchema.destroy_all
-      
+
       Hyrax::FlexibleSchema.create do |f|
         f.profile = YAML.safe_load_file(m3_profile_path)
       end
     end
 
-    private
-
     def self.tenant_specific_profile_path
       return default_profile_path unless defined?(Account)
-      
+
       current_tenant = Apartment::Tenant.current
       return default_profile_path unless current_tenant
-      
+
       account = Account.find_by(tenant: current_tenant)
       return default_profile_path unless account
-      
-     TenantWorkTypeFilter.tenant_metadata_profile_path(default_profile_path)
+
+      TenantWorkTypeFilter.tenant_metadata_profile_path(default_profile_path)
     end
 
     def self.default_profile_path
@@ -46,3 +45,4 @@ Rails.application.config.after_initialize do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/config/metadata_profiles/default/m3_profile.yaml
+++ b/config/metadata_profiles/default/m3_profile.yaml
@@ -1,0 +1,1807 @@
+---
+m3_version: 1.0.beta2
+profile:
+  date_modified: "2024-06-01"
+  responsibility: https://samvera.org
+  responsibility_statement: HykuUp Initial Profile
+  type: Hyku Profile with HykuUp Custom Work Types
+  version: 1
+classes:
+  GenericWorkResource:
+    display_label: Generic Work
+  ImageResource:
+    display_label: Image
+  OerResource:
+    display_label: OER
+  EtdResource:
+    display_label: ETD
+  AdminSetResource:
+    display_label: AdminSetResource
+  CollectionResource:
+    display_label: Collection Resource
+  Hyrax::FileSet:
+    display_label: FileSet
+contexts:
+  flexible_context:
+    display_label: Flexible Metadata Example
+  special_context:
+    display_label: Special Context
+mappings:
+  blacklight:
+    name: Additional Blacklight Solr Mappings
+  metatags:
+    name: Metatags
+  mods_oai_pmh:
+    name: MODS OAI PMH
+  qualified_dc_pmh:
+    name: Qualified DC OAI PMH
+  simple_dc_pmh:
+    name: Simple DC OAI PMH
+properties:
+  title:
+    available_on:
+      class:
+        - AdminSetResource
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    definition:
+      default:
+        Enter a standardized title for display. If only one title is needed,
+        transcribe the title from the source itself.
+    display_label:
+      default: Title
+    index_documentation: displayable, searchable
+    indexing:
+      - title_sim
+      - title_tesim
+    form:
+      required: true
+      primary: true
+    mappings:
+      metatags: twitter:title, og:title
+      mods_oai_pmh: mods:titleInfo/mods:title
+      qualified_dc_pmh: dcterms:title
+      simple_dc_pmh: dc:title
+    property_uri: http://purl.org/dc/terms/title
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Pencil drawn portrait study of woman
+    view:
+      label:
+        en: "Title"
+        es: "Título"
+      html_dl: true
+  date_modified:
+    available_on:
+      class:
+        - AdminSetResource
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    display_label:
+      default: Date Modified
+    property_uri: http://purl.org/dc/terms/modified
+    range: http://www.w3.org/2001/XMLSchema#dateTime
+    sample_values:
+      - "2024-06-06 21:06:51 +0000"
+    view:
+      label:
+        de: "Zuletzt geändert"
+        en: "Last modified"
+        es: "Última modificación"
+        fr: "Dernière modification"
+        it: "Ultima modifica"
+        pt-BR: "Última modificação"
+        zh: "最新修改"
+      html_dl: true
+  date_uploaded:
+    available_on:
+      class:
+        - AdminSetResource
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    display_label:
+      default: Date Uploaded
+    property_uri: http://purl.org/dc/terms/dateSubmitted
+    range: http://www.w3.org/2001/XMLSchema#dateTime
+    sample_values:
+      - "2024-06-06 21:06:51 +0000"
+  depositor:
+    available_on:
+      class:
+        - AdminSetResource
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Depositor
+    index_documentation: searchable
+    indexing:
+      - depositor_tesim
+      - depositor_ssim
+    property_uri: http://id.loc.gov/vocabulary/relators/dpt
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Julie Allinson
+  creator:
+    available_on:
+      class:
+        - AdminSetResource
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Creator
+    index_documentation: displayable, searchable
+    indexing:
+      - creator_sim
+      - creator_tesim
+    form:
+      required: true
+      primary: true
+    property_uri: http://purl.org/dc/elements/1.1/creator
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Julie Allinson
+    view:
+      render_as: "faceted"
+      html_dl: true
+  license:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "licenses"
+    display_label:
+      default: License
+    index_documentation: displayable, searchable
+    indexing:
+      - license_sim
+      - license_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/license
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - http://creativecommons.org/licenses/by/3.0/us/
+    view:
+      render_as: "external_link"
+      html_dl: true
+  abstract:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Abstract
+    index_documentation: displayable, searchable
+    indexing:
+      - abstract_sim
+      - abstract_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/abstract
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - This is an abstract.
+    view:
+      html_dl: true
+  access_right:
+    available_on:
+      class:
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Access Right
+    index_documentation: displayable, searchable
+    indexing:
+      - access_right_sim
+      - access_right_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/accessRights
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Open Access
+    view:
+      html_dl: true
+  alternative_title:
+    available_on:
+      class:
+        - AdminSetResource
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Alternative Title
+    index_documentation: displayable, searchable
+    indexing:
+      - alternative_title_sim
+      - alternative_title_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/alternative
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Alternate Title Example
+    view:
+      label:
+        en: "Alternative Title"
+        es: "Título Alternativo"
+      html_dl: true
+  arkivo_checksum:
+    available_on:
+      class:
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Arkivo Checksum
+    form:
+      primary: false
+    property_uri: http://scholarsphere.psu.edu/ns#arkivoChecksum
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - c0855931b7f1aefedb91d31af76873c0
+  based_near:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Location
+    index_documentation: displayable, searchable
+    indexing:
+      - based_near_sim
+      - based_near_tesim
+    form:
+      primary: false
+    property_uri: http://xmlns.com/foaf/0.1/based_near
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - San Diego, California, United States
+    view:
+      label: Based Near
+      render_term: "based_near_label"
+      html_dl: true
+  bibliographic_citation:
+    available_on:
+      class:
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Bibliographic Citation
+    index_documentation: displayable, searchable
+    indexing:
+      - bibliographic_citation_sim
+      - bibliographic_citation_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/bibliographicCitation
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Doe, J. (2024). Example Citation. Journal of Examples, 12(3), 45-67.
+    view:
+      html_dl: true
+  contributor:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Contributor
+    index_documentation: displayable, searchable
+    indexing:
+      - contributor_tesim
+      - contributor_sim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/elements/1.1/contributor
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Julie Allinson
+    view:
+      render_as: "faceted"
+      html_dl: true
+  date_created:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#dateTime
+      sources:
+        - "null"
+    display_label:
+      default: Date Created
+    index_documentation: displayable, searchable
+    indexing:
+      - date_created_sim
+      - date_created_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/created
+    range: http://www.w3.org/2001/XMLSchema#dateTime
+    sample_values:
+      - "2024-06-06 21:06:51 +0000"
+    view:
+      render_as: "linked"
+      search_field: "date_created_tesim"
+      html_dl: true
+  description:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Description
+    index_documentation: displayable, searchable
+    indexing:
+      - description_sim
+      - description_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/elements/1.1/description
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - This is a description.
+  identifier:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Identifier
+    index_documentation: displayable, searchable
+    indexing:
+      - identifier_sim
+      - identifier_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/identifier
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - abc123
+    view:
+      render_as: "linked"
+      search_field: "identifier_tesim"
+      html_dl: true
+  import_url:
+    available_on:
+      class:
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Import URL
+    property_uri: http://scholarsphere.psu.edu/ns#importUrl
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - http://example.com/resource1
+  keyword:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Keyword
+    index_documentation: displayable, searchable
+    indexing:
+      - keyword_sim
+      - keyword_tesim
+    form:
+      primary: false
+    property_uri: http://schema.org/keywords
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Metadata
+      - Repository
+    view:
+      render_as: "faceted"
+      html_dl: true
+  label:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Label
+    index_documentation: displayable, searchable
+    indexing:
+      - label_sim
+      - label_tesim
+    form:
+      primary: false
+    property_uri: info:fedora/fedora-system:def/model#downloadFilename
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - file_label.txt
+  language:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Language
+    index_documentation: displayable, searchable
+    indexing:
+      - language_sim
+      - language_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/elements/1.1/language
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - English
+      - Spanish
+    view:
+      render_as: "faceted"
+      html_dl: true
+  publisher:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Publisher
+    index_documentation: displayable, searchable
+    indexing:
+      - publisher_sim
+      - publisher_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/elements/1.1/publisher
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Scholastic
+    view:
+      render_as: "faceted"
+      html_dl: true
+  related_url:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Related URL
+    index_documentation: displayable, searchable
+    indexing:
+      - related_url_sim
+      - related_url_tesim
+    form:
+      primary: false
+    property_uri: http://www.w3.org/2000/01/rdf-schema#seeAlso
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - http://example.com/resource1
+    view:
+      render_as: "external_link"
+      html_dl: true
+  relative_path:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Relative Path
+    property_uri: http://scholarsphere.psu.edu/ns#relativePath
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "/path/to/resource"
+  resource_type:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "resource_types"
+    display_label:
+      default: Resource Type
+    index_documentation: displayable, searchable
+    indexing:
+      - resource_type_sim
+      - resource_type_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/type
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Article
+      - Conference Proceeding
+    view:
+      render_as: "faceted"
+      html_dl: true
+  rights_notes:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Rights Notes
+    index_documentation: displayable, searchable
+    indexing:
+      - rights_notes_sim
+      - rights_notes_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/elements/1.1/rights
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Creative Commons license.
+    view:
+      html_dl: true
+  rights_statement:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "rights_statements"
+    display_label:
+      default: Rights Statement
+    index_documentation: displayable, searchable
+    indexing:
+      - rights_statement_sim
+      - rights_statement_tesim
+    form:
+      primary: true
+      required: true
+    property_uri: http://www.europeana.eu/schemas/edm/rights
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - http://rightsstatements.org/vocab/InC/1.0/
+    view:
+      html_dl: true
+      render_as: "rights_statement"
+  source:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Source
+    index_documentation: displayable, searchable
+    indexing:
+      - source_sim
+      - source_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/source
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Original Manuscript
+      - Digital Archive
+    view:
+      html_dl: true
+  subject:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Subject
+    index_documentation: displayable, searchable
+    indexing:
+      - subject_sim
+      - subject_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/elements/1.1/subject
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Art
+      - Science
+    view:
+      render_as: "faceted"
+      html_dl: true
+  department:
+    available_on:
+      class:
+        - CollectionResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Department
+    form:
+      primary: true
+    property_uri: http://hyrax-example.com/department
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Mathematics
+      - History
+    view:
+      html_dl: true
+  course:
+    available_on:
+      class:
+        - CollectionResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Course
+    form:
+      primary: false
+    property_uri: http://hyrax-example.com/course
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Computer Science 50
+    view:
+      html_dl: true
+  format:
+    available_on:
+      class:
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Format
+    index_documentation: searchable
+    indexing:
+      - "format_tesim"
+    form:
+      required: false
+      primary: false
+      multiple: true
+    property_uri: http://purl.org/dc/terms/format
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - PDF
+  # Image-specific metadata from image_resource.yaml
+  extent:
+    available_on:
+      class:
+        - ImageResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Extent
+    index_documentation: searchable
+    indexing:
+      - "extent_tesim"
+    form:
+      required: false
+      primary: false
+      multiple: true
+    property_uri: http://purl.org/dc/terms/extent
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "300 dpi"
+      - "1024x768 pixels"
+  # OER-specific metadata from oer_resource.yaml
+  accessibility_feature:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Accessibility Feature
+    index_documentation: displayable, searchable
+    indexing:
+      - "accessibility_feature_tesim"
+      - "accessibility_feature_sim"
+    form:
+      primary: false
+      multiple: true
+    property_uri: http://schema.org/accessibilityFeature
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Subtitles
+      - Audio Description
+      - Transcripts
+  accessibility_hazard:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Accessibility Hazard
+    index_documentation: displayable, searchable
+    indexing:
+      - "accessibility_hazard_tesim"
+      - "accessibility_hazard_sim"
+    form:
+      primary: false
+      multiple: true
+    property_uri: http://schema.org/accessibilityHazard
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Motion Simulation
+  accessibility_summary:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Accessibility Summary
+    index_documentation: displayable, searchable
+    indexing:
+      - "accessibility_summary_tesim"
+      - "accessibility_summary_sim"
+    form:
+      primary: false
+      multiple: false
+    property_uri: http://schema.org/accessibilitySummary
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - This resource includes subtitles for all video content.
+      - The resource provides text descriptions for all images.
+  admin_note:
+    available_on:
+      class:
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Admin Note
+    index_documentation: searchable
+    indexing:
+      - "admin_note_tesim"
+    form:
+      primary: false
+      multiple: false
+    property_uri: http://schema.org/positiveNotes
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - This is an admin note.
+      - Another example of an admin note.
+    view:
+      html_dl: true
+  additional_information:
+    available_on:
+      class:
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Additional Information
+    index_documentation: searchable
+    indexing:
+      - "additional_information_tesim"
+    form:
+      primary: false
+      multiple: true
+    property_uri: http://purl.org/dc/terms/accessRights
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - This is some additional information.
+      - More details and context.
+  alternate_version_id:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Alternate Version ID
+    index_documentation: displayable, searchable
+    indexing:
+      - "alternate_version_id_tesim"
+      - "alternate_version_id_sim"
+    property_uri: http://purl.org/dc/terms/hasVersion
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - alt_version_1
+      - alt_version_2
+  audience:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "audience"
+    display_label:
+      default: Audience
+    index_documentation: displayable, searchable
+    indexing:
+      - "audience_tesim"
+      - "audience_sim"
+    form:
+      required: true
+      primary: true
+    property_uri: http://schema.org/EducationalAudience
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Student
+      - Instructor
+    view:
+      html_dl: true
+      render_as: "faceted"
+  date:
+    available_on:
+      class:
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Date
+    index_documentation: displayable, searchable
+    indexing:
+      - "date_tesim"
+      - "date_sim"
+    property_uri: https://hykucommons.org/terms/date
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "2024-06-07"
+      - "2023-05-12"
+  discipline:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "discipline"
+    display_label:
+      default: Discipline
+    index_documentation: searchable
+    indexing:
+      - "discipline_tesim"
+    form:
+      required: true
+      primary: true
+    property_uri: https://hykucommons.org/terms/degree_discipline
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "Languages - Spanish"
+      - "Natural Sciences - Physics"
+    view:
+      html_dl: true
+      render_as: "faceted"
+  education_level:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "education_levels"
+    display_label:
+      default: Education Level
+    index_documentation: displayable, searchable
+    indexing:
+      - "education_level_tesim"
+      - "education_level_sim"
+    form:
+      required: true
+      primary: true
+    property_uri: http://purl.org/dc/terms/educationLevel
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "Community college / Lower division"
+      - "College / Upper division"
+    view:
+      html_dl: true
+      render_as: "faceted"
+  learning_resource_type:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "learning_resource_types"
+    display_label:
+      default: Learning Resource Type
+    index_documentation: displayable, searchable
+    indexing:
+      - "learning_resource_type_tesim"
+      - "learning_resource_type_sim"
+    form:
+      required: true
+      primary: true
+    property_uri: http://schema.org/learningResourceType
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "Activity/lab"
+      - "Assessment (test, quizzes, etc.)"
+    view:
+      html_dl: true
+      render_as: "faceted"
+  newer_version_id:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Newer Version ID
+    index_documentation: displayable, searchable
+    indexing:
+      - "newer_version_id_tesim"
+      - "newer_version_id_sim"
+    property_uri: http://purl.org/dc/terms/isReplacedBy
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - new_version_1
+      - new_version_2
+  oer_size:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: OER Size
+    index_documentation: searchable
+    indexing:
+      - "oer_size_tesim"
+    form:
+      primary: false
+      multiple: true
+    property_uri: http://purl.org/dc/terms/extent
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - 15MB
+      - 200 pages
+  previous_version_id:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Previous Version ID
+    index_documentation: displayable, searchable
+    indexing:
+      - "previous_version_id_tesim"
+      - "previous_version_id_sim"
+    property_uri: http://purl.org/dc/terms/replaces
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - prev_version_1
+      - prev_version_2
+  related_item_id:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Related Item ID
+    index_documentation: displayable, searchable
+    indexing:
+      - "related_item_id_tesim"
+      - "related_item_id_sim"
+    property_uri: http://purl.org/dc/terms/relation
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - related_item_1
+      - related_item_2
+  rights_holder:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Rights Holder
+    index_documentation: displayable, searchable
+    indexing:
+      - "rights_holder_tesim"
+      - "rights_holder_sim"
+    form:
+      primary: false
+      multiple: true
+    property_uri: http://purl.org/dc/terms/rightsHolder
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - John Doe
+      - Jane Smith
+  table_of_contents:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Table of Contents
+    index_documentation: searchable
+    indexing:
+      - "table_of_contents_tesim"
+    form:
+      primary: false
+      multiple: true
+    property_uri: http://purl.org/dc/terms/tableOfContents
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "Chapter 1: Introduction"
+      - "Chapter 2: Literature Review"
+      - "Chapter 3: Methodology"
+  # ETD-specific metadata - etd_resource.yaml
+  advisor:
+    available_on:
+      class:
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Advisor
+    index_documentation: searchable
+    indexing:
+      - "advisor_tesim"
+    form:
+      required: false
+      primary: false
+      multiple: true
+    property_uri: https://hykucommons.org/terms/advisor
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Dr. John Doe
+      - Dr. Jane Smith
+  committee_member:
+    available_on:
+      class:
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Committee Member
+    index_documentation: searchable
+    indexing:
+      - "committee_member_tesim"
+    form:
+      required: false
+      primary: false
+      multiple: true
+    property_uri: https://hykucommons.org/terms/committee_member
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Dr. John Doe
+      - Dr. Jane Smith
+  degree_name:
+    available_on:
+      class:
+        - EtdResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Degree Name
+    index_documentation: searchable
+    indexing:
+      - "degree_name_tesim"
+    form:
+      required: true
+      primary: true
+      multiple: true
+    property_uri: https://hykucommons.org/terms/degree_name
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Bachelor of Science
+      - Master of Arts
+    view:
+      html_dl: true
+  degree_level:
+    available_on:
+      class:
+        - EtdResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Degree Level
+    index_documentation: searchable
+    indexing:
+      - "degree_level_tesim"
+    form:
+      required: true
+      primary: true
+      multiple: true
+    property_uri: https://hykucommons.org/terms/degree_level
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Undergraduate
+      - Graduate
+    view:
+      html_dl: true
+  degree_discipline:
+    available_on:
+      class:
+        - EtdResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Degree Discipline
+    index_documentation: searchable
+    indexing:
+      - "degree_discipline_tesim"
+    form:
+      required: true
+      primary: true
+      multiple: true
+    property_uri: https://hykucommons.org/terms/degree_discipline
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Computer Science
+      - Biology
+    view:
+      html_dl: true
+  degree_grantor:
+    available_on:
+      class:
+        - EtdResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Degree Grantor
+    index_documentation: searchable
+    indexing:
+      - "degree_grantor_tesim"
+    form:
+      required: true
+      primary: true
+      multiple: true
+    property_uri: https://hykucommons.org/terms/degree_grantor
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - University of Example
+      - Example State University
+    view:
+      html_dl: true
+  # Bulkrax metadata from bulkrax_metadata.yaml
+  bulkrax_identifier:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Bulkrax Identifier
+    index_documentation: displayable, searchable
+    indexing:
+      - "bulkrax_identifier_tesi"
+      - "bulkrax_identifier_ssi"
+    form:
+      display: false
+      primary: false
+      required: false
+      multiple: false
+    property_uri: https://hykucommons.org/terms/bulkrax_identifier
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - example-bulkrax-identifier
+  # PDF.js metadata from with_pdf_viewer.yaml
+  show_pdf_viewer:
+    available_on:
+      class:
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#bool
+      sources:
+        - "null"
+    display_label:
+      default: Show PDF Viewer
+    index_documentation: displayable, searchable
+    indexing:
+      - "show_pdf_viewer_bsi"
+    form:
+      display: false
+      primary: false
+      required: false
+      multiple: false
+    property_uri: http://id.loc.gov/vocabulary/identifiers/show_pdf_viewer
+    range: http://www.w3.org/2001/XMLSchema#bool
+    sample_values:
+      - "0"
+      - "1"
+  show_pdf_download_button:
+    available_on:
+      class:
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#bool
+      sources:
+        - "null"
+    display_label:
+      default: Show PDF Download Button
+    index_documentation: displayable, searchable
+    indexing:
+      - "show_pdf_download_button_bsi"
+    form:
+      display: false
+      primary: false
+      required: false
+      multiple: false
+    property_uri: http://id.loc.gov/vocabulary/identifiers/show_pdf_download_button
+    range: http://www.w3.org/2001/XMLSchema#bool
+    sample_values:
+      - "0"
+      - "1"
+  # Video Embed metadata - with_video_embed.yaml
+  video_embed:
+    available_on:
+      class:
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Video Embed
+    index_documentation: searchable
+    indexing:
+      - "video_embed_tesi"
+    form:
+      display: true
+      primary: false
+      required: false
+      multiple: false
+    property_uri: https://atla.com/terms/video_embed
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "https://player.vimeo.com/video/467264493?h=b089de0eab"
+      - "https://www.youtube.com/embed/Znf73dsFdC8"
+  # IiifPrint metadata - child_works_from_pdf_splitting.yaml
+  is_child:
+    available_on:
+      class:
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#bool
+      sources:
+        - "null"
+    display_label:
+      default: Is Child
+    index_documentation: displayable, searchable
+    indexing:
+      - "is_child_bsi"
+    form:
+      display: false
+      required: false
+      primary: false
+      multiple: false
+    property_uri: http://id.loc.gov/vocabulary/identifiers/isChild
+    range: http://www.w3.org/2001/XMLSchema#bool
+    sample_values:
+      - true
+      - false
+  split_from_pdf_id:
+    available_on:
+      class:
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Split from PDF ID
+    index_documentation: searchable
+    indexing:
+      - "split_from_pdf_id_ssi"
+    form:
+      display: false
+      required: false
+      primary: false
+      multiple: false
+    property_uri: http://id.loc.gov/vocabulary/identifiers/splitFromPdfId
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - example-split-from-pdf-id
+  # Special context metadata
+  dimensions:
+    available_on:
+      class:
+        - ImageResource
+      context:
+        - special_context
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Dimensions
+    index_documentation: displayable, searchable
+    indexing:
+      - dimensions_sim
+      - dimensions_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/format
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - 50" x 20"
+      - 5 m x 10 m x 8 m
+    view:
+      render_as: "faceted"
+      html_dl: true
+  hide_from_catalog_search:
+    available_on:
+      class:
+        - CollectionResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#bool
+      sources:
+        - "null"
+    display_label:
+      default: Hide from Catalog Search
+    index_documentation: displayable, searchable
+    indexing:
+      - hide_from_catalog_search_bsi
+      - hide_from_catalog_search_tesim
+    form:
+      display: false
+      primary: false
+      required: false
+      multiple: false
+    property_uri: https://hykucommons.org/terms/hide_from_catalog_search
+    range: http://www.w3.org/2001/XMLSchema#bool
+    sample_values:
+      - true
+      - false

--- a/config/metadata_profiles/default/m3_profile.yaml
+++ b/config/metadata_profiles/default/m3_profile.yaml
@@ -4,7 +4,7 @@ profile:
   date_modified: "2024-06-01"
   responsibility: https://samvera.org
   responsibility_statement: HykuUp Initial Profile
-  type: Hyku Profile with HykuUp Custom Work Types
+  type: Default HykuUp Profile
   version: 1
 classes:
   GenericWorkResource:

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -4,7 +4,7 @@ profile:
   date_modified: "2024-06-01"
   responsibility: https://samvera.org
   responsibility_statement: HykuUp Initial Profile
-  type: Hyku Profile with HykuUp Custom Work Types
+  type: Default HykuUp Profile
   version: 1
 classes:
   GenericWorkResource:

--- a/config/metadata_profiles/mobius/m3_profile.yaml
+++ b/config/metadata_profiles/mobius/m3_profile.yaml
@@ -1,0 +1,1930 @@
+---
+m3_version: 1.0.beta2
+profile:
+  date_modified: "2024-06-01"
+  responsibility: https://samvera.org
+  responsibility_statement: Mobius Initial Profile
+  type: Hyku Profile with Mobius Custom Work Types
+  version: 1
+classes:
+  GenericWorkResource:
+    display_label: Generic Work
+  ImageResource:
+    display_label: Image
+  OerResource:
+    display_label: OER
+  EtdResource:
+    display_label: ETD
+  AdminSetResource:
+    display_label: AdminSetResource
+  CollectionResource:
+    display_label: Collection Resource
+  Hyrax::FileSet:
+    display_label: FileSet
+  MobiusWork:
+    display_label: Mobius Work
+contexts:
+  flexible_context:
+    display_label: Flexible Metadata Example
+  special_context:
+    display_label: Special Context
+mappings:
+  blacklight:
+    name: Additional Blacklight Solr Mappings
+  metatags:
+    name: Metatags
+  mods_oai_pmh:
+    name: MODS OAI PMH
+  qualified_dc_pmh:
+    name: Qualified DC OAI PMH
+  simple_dc_pmh:
+    name: Simple DC OAI PMH
+properties:
+  title:
+    available_on:
+      class:
+        - AdminSetResource
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    definition:
+      default:
+        Enter a standardized title for display. If only one title is needed,
+        transcribe the title from the source itself.
+    display_label:
+      default: Title
+    index_documentation: displayable, searchable
+    indexing:
+      - title_sim
+      - title_tesim
+    form:
+      required: true
+      primary: true
+    mappings:
+      metatags: twitter:title, og:title
+      mods_oai_pmh: mods:titleInfo/mods:title
+      qualified_dc_pmh: dcterms:title
+      simple_dc_pmh: dc:title
+    property_uri: http://purl.org/dc/terms/title
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Pencil drawn portrait study of woman
+    view:
+      label:
+        en: "Title"
+        es: "Título"
+      html_dl: true
+  date_modified:
+    available_on:
+      class:
+        - AdminSetResource
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    display_label:
+      default: Date Modified
+    property_uri: http://purl.org/dc/terms/modified
+    range: http://www.w3.org/2001/XMLSchema#dateTime
+    sample_values:
+      - "2024-06-06 21:06:51 +0000"
+    view:
+      label:
+        de: "Zuletzt geändert"
+        en: "Last modified"
+        es: "Última modificación"
+        fr: "Dernière modification"
+        it: "Ultima modifica"
+        pt-BR: "Última modificação"
+        zh: "最新修改"
+      html_dl: true
+  date_uploaded:
+    available_on:
+      class:
+        - AdminSetResource
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    display_label:
+      default: Date Uploaded
+    property_uri: http://purl.org/dc/terms/dateSubmitted
+    range: http://www.w3.org/2001/XMLSchema#dateTime
+    sample_values:
+      - "2024-06-06 21:06:51 +0000"
+  depositor:
+    available_on:
+      class:
+        - AdminSetResource
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Depositor
+    index_documentation: searchable
+    indexing:
+      - depositor_tesim
+      - depositor_ssim
+    property_uri: http://id.loc.gov/vocabulary/relators/dpt
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Julie Allinson
+  creator:
+    available_on:
+      class:
+        - AdminSetResource
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Creator
+    index_documentation: displayable, searchable
+    indexing:
+      - creator_sim
+      - creator_tesim
+    form:
+      required: true
+      primary: true
+    property_uri: http://purl.org/dc/elements/1.1/creator
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Julie Allinson
+    view:
+      render_as: "faceted"
+      html_dl: true
+  license:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "licenses"
+    display_label:
+      default: License
+    index_documentation: displayable, searchable
+    indexing:
+      - license_sim
+      - license_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/license
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - http://creativecommons.org/licenses/by/3.0/us/
+    view:
+      render_as: "external_link"
+      html_dl: true
+  abstract:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Abstract
+    index_documentation: displayable, searchable
+    indexing:
+      - abstract_sim
+      - abstract_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/abstract
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - This is an abstract.
+    view:
+      html_dl: true
+  access_right:
+    available_on:
+      class:
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Access Right
+    index_documentation: displayable, searchable
+    indexing:
+      - access_right_sim
+      - access_right_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/accessRights
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Open Access
+    view:
+      html_dl: true
+  alternative_title:
+    available_on:
+      class:
+        - AdminSetResource
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Alternative Title
+    index_documentation: displayable, searchable
+    indexing:
+      - alternative_title_sim
+      - alternative_title_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/alternative
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Alternate Title Example
+    view:
+      label:
+        en: "Alternative Title"
+        es: "Título Alternativo"
+      html_dl: true
+  arkivo_checksum:
+    available_on:
+      class:
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Arkivo Checksum
+    form:
+      primary: false
+    property_uri: http://scholarsphere.psu.edu/ns#arkivoChecksum
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - c0855931b7f1aefedb91d31af76873c0
+  based_near:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Location
+    index_documentation: displayable, searchable
+    indexing:
+      - based_near_sim
+      - based_near_tesim
+    form:
+      primary: false
+    property_uri: http://xmlns.com/foaf/0.1/based_near
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - San Diego, California, United States
+    view:
+      label: Based Near
+      render_term: "based_near_label"
+      html_dl: true
+  bibliographic_citation:
+    available_on:
+      class:
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Bibliographic Citation
+    index_documentation: displayable, searchable
+    indexing:
+      - bibliographic_citation_sim
+      - bibliographic_citation_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/bibliographicCitation
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Doe, J. (2024). Example Citation. Journal of Examples, 12(3), 45-67.
+    view:
+      html_dl: true
+  contributor:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Contributor
+    index_documentation: displayable, searchable
+    indexing:
+      - contributor_tesim
+      - contributor_sim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/elements/1.1/contributor
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Julie Allinson
+    view:
+      render_as: "faceted"
+      html_dl: true
+  date_created:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#dateTime
+      sources:
+        - "null"
+    display_label:
+      default: Date Created
+    index_documentation: displayable, searchable
+    indexing:
+      - date_created_sim
+      - date_created_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/created
+    range: http://www.w3.org/2001/XMLSchema#dateTime
+    sample_values:
+      - "2024-06-06 21:06:51 +0000"
+    view:
+      render_as: "linked"
+      search_field: "date_created_tesim"
+      html_dl: true
+  description:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Description
+    index_documentation: displayable, searchable
+    indexing:
+      - description_sim
+      - description_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/elements/1.1/description
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - This is a description.
+  identifier:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Identifier
+    index_documentation: displayable, searchable
+    indexing:
+      - identifier_sim
+      - identifier_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/identifier
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - abc123
+    view:
+      render_as: "linked"
+      search_field: "identifier_tesim"
+      html_dl: true
+  import_url:
+    available_on:
+      class:
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Import URL
+    property_uri: http://scholarsphere.psu.edu/ns#importUrl
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - http://example.com/resource1
+  keyword:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Keyword
+    index_documentation: displayable, searchable
+    indexing:
+      - keyword_sim
+      - keyword_tesim
+    form:
+      primary: false
+    property_uri: http://schema.org/keywords
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Metadata
+      - Repository
+    view:
+      render_as: "faceted"
+      html_dl: true
+  label:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Label
+    index_documentation: displayable, searchable
+    indexing:
+      - label_sim
+      - label_tesim
+    form:
+      primary: false
+    property_uri: info:fedora/fedora-system:def/model#downloadFilename
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - file_label.txt
+  language:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Language
+    index_documentation: displayable, searchable
+    indexing:
+      - language_sim
+      - language_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/elements/1.1/language
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - English
+      - Spanish
+    view:
+      render_as: "faceted"
+      html_dl: true
+  publisher:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Publisher
+    index_documentation: displayable, searchable
+    indexing:
+      - publisher_sim
+      - publisher_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/elements/1.1/publisher
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Scholastic
+    view:
+      render_as: "faceted"
+      html_dl: true
+  related_url:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Related URL
+    index_documentation: displayable, searchable
+    indexing:
+      - related_url_sim
+      - related_url_tesim
+    form:
+      primary: false
+    property_uri: http://www.w3.org/2000/01/rdf-schema#seeAlso
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - http://example.com/resource1
+    view:
+      render_as: "external_link"
+      html_dl: true
+  relative_path:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Relative Path
+    property_uri: http://scholarsphere.psu.edu/ns#relativePath
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "/path/to/resource"
+  resource_type:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "resource_types"
+    display_label:
+      default: Resource Type
+    index_documentation: displayable, searchable
+    indexing:
+      - resource_type_sim
+      - resource_type_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/type
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Article
+      - Conference Proceeding
+    view:
+      render_as: "faceted"
+      html_dl: true
+  rights_notes:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Rights Notes
+    index_documentation: displayable, searchable
+    indexing:
+      - rights_notes_sim
+      - rights_notes_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/elements/1.1/rights
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Creative Commons license.
+    view:
+      html_dl: true
+  rights_statement:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "rights_statements"
+    display_label:
+      default: Rights Statement
+    index_documentation: displayable, searchable
+    indexing:
+      - rights_statement_sim
+      - rights_statement_tesim
+    form:
+      primary: true
+      required: true
+    property_uri: http://www.europeana.eu/schemas/edm/rights
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - http://rightsstatements.org/vocab/InC/1.0/
+    view:
+      html_dl: true
+      render_as: "rights_statement"
+  source:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Source
+    index_documentation: displayable, searchable
+    indexing:
+      - source_sim
+      - source_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/source
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Original Manuscript
+      - Digital Archive
+    view:
+      html_dl: true
+  subject:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Subject
+    index_documentation: displayable, searchable
+    indexing:
+      - subject_sim
+      - subject_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/elements/1.1/subject
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Art
+      - Science
+    view:
+      render_as: "faceted"
+      html_dl: true
+  department:
+    available_on:
+      class:
+        - CollectionResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Department
+    form:
+      primary: true
+    property_uri: http://hyrax-example.com/department
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Mathematics
+      - History
+    view:
+      html_dl: true
+  course:
+    available_on:
+      class:
+        - CollectionResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Course
+    form:
+      primary: false
+    property_uri: http://hyrax-example.com/course
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Computer Science 50
+    view:
+      html_dl: true
+  format:
+    available_on:
+      class:
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Format
+    index_documentation: searchable
+    indexing:
+      - "format_tesim"
+    form:
+      required: false
+      primary: false
+      multiple: true
+    property_uri: http://purl.org/dc/terms/format
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - PDF
+  # Image-specific metadata from image_resource.yaml
+  extent:
+    available_on:
+      class:
+        - ImageResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Extent
+    index_documentation: searchable
+    indexing:
+      - "extent_tesim"
+    form:
+      required: false
+      primary: false
+      multiple: true
+    property_uri: http://purl.org/dc/terms/extent
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "300 dpi"
+      - "1024x768 pixels"
+  # OER-specific metadata from oer_resource.yaml
+  accessibility_feature:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Accessibility Feature
+    index_documentation: displayable, searchable
+    indexing:
+      - "accessibility_feature_tesim"
+      - "accessibility_feature_sim"
+    form:
+      primary: false
+      multiple: true
+    property_uri: http://schema.org/accessibilityFeature
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Subtitles
+      - Audio Description
+      - Transcripts
+  accessibility_hazard:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Accessibility Hazard
+    index_documentation: displayable, searchable
+    indexing:
+      - "accessibility_hazard_tesim"
+      - "accessibility_hazard_sim"
+    form:
+      primary: false
+      multiple: true
+    property_uri: http://schema.org/accessibilityHazard
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Motion Simulation
+  accessibility_summary:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Accessibility Summary
+    index_documentation: displayable, searchable
+    indexing:
+      - "accessibility_summary_tesim"
+      - "accessibility_summary_sim"
+    form:
+      primary: false
+      multiple: false
+    property_uri: http://schema.org/accessibilitySummary
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - This resource includes subtitles for all video content.
+      - The resource provides text descriptions for all images.
+  admin_note:
+    available_on:
+      class:
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Admin Note
+    index_documentation: searchable
+    indexing:
+      - "admin_note_tesim"
+    form:
+      primary: false
+      multiple: false
+    property_uri: http://schema.org/positiveNotes
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - This is an admin note.
+      - Another example of an admin note.
+    view:
+      html_dl: true
+  additional_information:
+    available_on:
+      class:
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Additional Information
+    index_documentation: searchable
+    indexing:
+      - "additional_information_tesim"
+    form:
+      primary: false
+      multiple: true
+    property_uri: http://purl.org/dc/terms/accessRights
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - This is some additional information.
+      - More details and context.
+  alternate_version_id:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Alternate Version ID
+    index_documentation: displayable, searchable
+    indexing:
+      - "alternate_version_id_tesim"
+      - "alternate_version_id_sim"
+    property_uri: http://purl.org/dc/terms/hasVersion
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - alt_version_1
+      - alt_version_2
+  audience:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "audience"
+    display_label:
+      default: Audience
+    index_documentation: displayable, searchable
+    indexing:
+      - "audience_tesim"
+      - "audience_sim"
+    form:
+      required: true
+      primary: true
+    property_uri: http://schema.org/EducationalAudience
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Student
+      - Instructor
+    view:
+      html_dl: true
+      render_as: "faceted"
+  date:
+    available_on:
+      class:
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Date
+    index_documentation: displayable, searchable
+    indexing:
+      - "date_tesim"
+      - "date_sim"
+    property_uri: https://hykucommons.org/terms/date
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "2024-06-07"
+      - "2023-05-12"
+  discipline:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "discipline"
+    display_label:
+      default: Discipline
+    index_documentation: searchable
+    indexing:
+      - "discipline_tesim"
+    form:
+      required: true
+      primary: true
+    property_uri: https://hykucommons.org/terms/degree_discipline
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "Languages - Spanish"
+      - "Natural Sciences - Physics"
+    view:
+      html_dl: true
+      render_as: "faceted"
+  education_level:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "education_levels"
+    display_label:
+      default: Education Level
+    index_documentation: displayable, searchable
+    indexing:
+      - "education_level_tesim"
+      - "education_level_sim"
+    form:
+      required: true
+      primary: true
+    property_uri: http://purl.org/dc/terms/educationLevel
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "Community college / Lower division"
+      - "College / Upper division"
+    view:
+      html_dl: true
+      render_as: "faceted"
+  learning_resource_type:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "learning_resource_types"
+    display_label:
+      default: Learning Resource Type
+    index_documentation: displayable, searchable
+    indexing:
+      - "learning_resource_type_tesim"
+      - "learning_resource_type_sim"
+    form:
+      required: true
+      primary: true
+    property_uri: http://schema.org/learningResourceType
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "Activity/lab"
+      - "Assessment (test, quizzes, etc.)"
+    view:
+      html_dl: true
+      render_as: "faceted"
+  newer_version_id:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Newer Version ID
+    index_documentation: displayable, searchable
+    indexing:
+      - "newer_version_id_tesim"
+      - "newer_version_id_sim"
+    property_uri: http://purl.org/dc/terms/isReplacedBy
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - new_version_1
+      - new_version_2
+  oer_size:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: OER Size
+    index_documentation: searchable
+    indexing:
+      - "oer_size_tesim"
+    form:
+      primary: false
+      multiple: true
+    property_uri: http://purl.org/dc/terms/extent
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - 15MB
+      - 200 pages
+  previous_version_id:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Previous Version ID
+    index_documentation: displayable, searchable
+    indexing:
+      - "previous_version_id_tesim"
+      - "previous_version_id_sim"
+    property_uri: http://purl.org/dc/terms/replaces
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - prev_version_1
+      - prev_version_2
+  related_item_id:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Related Item ID
+    index_documentation: displayable, searchable
+    indexing:
+      - "related_item_id_tesim"
+      - "related_item_id_sim"
+    property_uri: http://purl.org/dc/terms/relation
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - related_item_1
+      - related_item_2
+  rights_holder:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Rights Holder
+    index_documentation: displayable, searchable
+    indexing:
+      - "rights_holder_tesim"
+      - "rights_holder_sim"
+    form:
+      primary: false
+      multiple: true
+    property_uri: http://purl.org/dc/terms/rightsHolder
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - John Doe
+      - Jane Smith
+  table_of_contents:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Table of Contents
+    index_documentation: searchable
+    indexing:
+      - "table_of_contents_tesim"
+    form:
+      primary: false
+      multiple: true
+    property_uri: http://purl.org/dc/terms/tableOfContents
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "Chapter 1: Introduction"
+      - "Chapter 2: Literature Review"
+      - "Chapter 3: Methodology"
+  # ETD-specific metadata - etd_resource.yaml
+  advisor:
+    available_on:
+      class:
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Advisor
+    index_documentation: searchable
+    indexing:
+      - "advisor_tesim"
+    form:
+      required: false
+      primary: false
+      multiple: true
+    property_uri: https://hykucommons.org/terms/advisor
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Dr. John Doe
+      - Dr. Jane Smith
+  committee_member:
+    available_on:
+      class:
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Committee Member
+    index_documentation: searchable
+    indexing:
+      - "committee_member_tesim"
+    form:
+      required: false
+      primary: false
+      multiple: true
+    property_uri: https://hykucommons.org/terms/committee_member
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Dr. John Doe
+      - Dr. Jane Smith
+  degree_name:
+    available_on:
+      class:
+        - EtdResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Degree Name
+    index_documentation: searchable
+    indexing:
+      - "degree_name_tesim"
+    form:
+      required: true
+      primary: true
+      multiple: true
+    property_uri: https://hykucommons.org/terms/degree_name
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Bachelor of Science
+      - Master of Arts
+    view:
+      html_dl: true
+  degree_level:
+    available_on:
+      class:
+        - EtdResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Degree Level
+    index_documentation: searchable
+    indexing:
+      - "degree_level_tesim"
+    form:
+      required: true
+      primary: true
+      multiple: true
+    property_uri: https://hykucommons.org/terms/degree_level
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Undergraduate
+      - Graduate
+    view:
+      html_dl: true
+  degree_discipline:
+    available_on:
+      class:
+        - EtdResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Degree Discipline
+    index_documentation: searchable
+    indexing:
+      - "degree_discipline_tesim"
+    form:
+      required: true
+      primary: true
+      multiple: true
+    property_uri: https://hykucommons.org/terms/degree_discipline
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Computer Science
+      - Biology
+    view:
+      html_dl: true
+  degree_grantor:
+    available_on:
+      class:
+        - EtdResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Degree Grantor
+    index_documentation: searchable
+    indexing:
+      - "degree_grantor_tesim"
+    form:
+      required: true
+      primary: true
+      multiple: true
+    property_uri: https://hykucommons.org/terms/degree_grantor
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - University of Example
+      - Example State University
+    view:
+      html_dl: true
+  # MobiusWork specific metadata - mobius_work.yaml
+  rights:
+    available_on:
+      class:
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Rights
+    index_documentation: searchable
+    indexing:
+      - rights_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/rightsHolder
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - All rights reserved.
+    view:
+      html_dl: true
+  relation:
+    available_on:
+      class:
+      - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+      - 'null'
+    display_label:
+      default: Relation
+    index_documentation: searchable
+    indexing:
+      - relation_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/relation
+    range: http://www.w3.org/2001/XMLSchema#string
+    view:
+      html_dl: true
+  coverage:
+    available_on:
+      class:
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Coverage
+    index_documentation: searchable
+    index_keys:
+      - "coverage_tesim"
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/coverage
+    range: http://www.w3.org/2001/XMLSchema#string
+    view:
+      html_dl: true
+  file_format:
+    available_on:
+      class:
+        - MobiusWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: File Format
+    index_documentation: searchable
+    indexing:
+      - file_format_tesim
+    form:
+      required: false
+      primary: false
+      multiple: true
+    property_uri: http://purl.org/dc/terms/format
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - JPEG
+      - PNG
+  # Bulkrax metadata from bulkrax_metadata.yaml
+  bulkrax_identifier:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Bulkrax Identifier
+    index_documentation: displayable, searchable
+    indexing:
+      - "bulkrax_identifier_tesi"
+      - "bulkrax_identifier_ssi"
+    form:
+      display: false
+      primary: false
+      required: false
+      multiple: false
+    property_uri: https://hykucommons.org/terms/bulkrax_identifier
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - example-bulkrax-identifier
+  # PDF.js metadata from with_pdf_viewer.yaml
+  show_pdf_viewer:
+    available_on:
+      class:
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#bool
+      sources:
+        - "null"
+    display_label:
+      default: Show PDF Viewer
+    index_documentation: displayable, searchable
+    indexing:
+      - "show_pdf_viewer_bsi"
+    form:
+      display: false
+      primary: false
+      required: false
+      multiple: false
+    property_uri: http://id.loc.gov/vocabulary/identifiers/show_pdf_viewer
+    range: http://www.w3.org/2001/XMLSchema#bool
+    sample_values:
+      - "0"
+      - "1"
+  show_pdf_download_button:
+    available_on:
+      class:
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#bool
+      sources:
+        - "null"
+    display_label:
+      default: Show PDF Download Button
+    index_documentation: displayable, searchable
+    indexing:
+      - "show_pdf_download_button_bsi"
+    form:
+      display: false
+      primary: false
+      required: false
+      multiple: false
+    property_uri: http://id.loc.gov/vocabulary/identifiers/show_pdf_download_button
+    range: http://www.w3.org/2001/XMLSchema#bool
+    sample_values:
+      - "0"
+      - "1"
+  # Video Embed metadata - with_video_embed.yaml
+  video_embed:
+    available_on:
+      class:
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Video Embed
+    index_documentation: searchable
+    indexing:
+      - "video_embed_tesi"
+    form:
+      display: true
+      primary: false
+      required: false
+      multiple: false
+    property_uri: https://atla.com/terms/video_embed
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "https://player.vimeo.com/video/467264493?h=b089de0eab"
+      - "https://www.youtube.com/embed/Znf73dsFdC8"
+  # IiifPrint metadata - child_works_from_pdf_splitting.yaml
+  is_child:
+    available_on:
+      class:
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#bool
+      sources:
+        - "null"
+    display_label:
+      default: Is Child
+    index_documentation: displayable, searchable
+    indexing:
+      - "is_child_bsi"
+    form:
+      display: false
+      required: false
+      primary: false
+      multiple: false
+    property_uri: http://id.loc.gov/vocabulary/identifiers/isChild
+    range: http://www.w3.org/2001/XMLSchema#bool
+    sample_values:
+      - true
+      - false
+  split_from_pdf_id:
+    available_on:
+      class:
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Split from PDF ID
+    index_documentation: searchable
+    indexing:
+      - "split_from_pdf_id_ssi"
+    form:
+      display: false
+      required: false
+      primary: false
+      multiple: false
+    property_uri: http://id.loc.gov/vocabulary/identifiers/splitFromPdfId
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - example-split-from-pdf-id
+  # Special context metadata
+  dimensions:
+    available_on:
+      class:
+        - ImageResource
+      context:
+        - special_context
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Dimensions
+    index_documentation: displayable, searchable
+    indexing:
+      - dimensions_sim
+      - dimensions_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/format
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - 50" x 20"
+      - 5 m x 10 m x 8 m
+    view:
+      render_as: "faceted"
+      html_dl: true
+  hide_from_catalog_search:
+    available_on:
+      class:
+        - CollectionResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#bool
+      sources:
+        - "null"
+    display_label:
+      default: Hide from Catalog Search
+    index_documentation: displayable, searchable
+    indexing:
+      - hide_from_catalog_search_bsi
+      - hide_from_catalog_search_tesim
+    form:
+      display: false
+      primary: false
+      required: false
+      multiple: false
+    property_uri: https://hykucommons.org/terms/hide_from_catalog_search
+    range: http://www.w3.org/2001/XMLSchema#bool
+    sample_values:
+      - true
+      - false

--- a/config/metadata_profiles/mobius/m3_profile.yaml
+++ b/config/metadata_profiles/mobius/m3_profile.yaml
@@ -1626,7 +1626,7 @@ properties:
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
-      - 'null'
+      - "null"
     display_label:
       default: Relation
     index_documentation: searchable
@@ -1652,7 +1652,7 @@ properties:
     display_label:
       default: Coverage
     index_documentation: searchable
-    index_keys:
+    indexing:
       - "coverage_tesim"
     form:
       primary: false

--- a/config/metadata_profiles/unca/m3_profile.yaml
+++ b/config/metadata_profiles/unca/m3_profile.yaml
@@ -8,7 +8,7 @@ profile:
   version: 1
 classes:
   GenericWorkResource:
-    display_label: Generic Worki461--up
+    display_label: Generic Work
   ImageResource:
     display_label: Image
   OerResource:

--- a/config/metadata_profiles/unca/m3_profile.yaml
+++ b/config/metadata_profiles/unca/m3_profile.yaml
@@ -1,0 +1,1952 @@
+---
+m3_version: 1.0.beta2
+profile:
+  date_modified: "2024-06-01"
+  responsibility: https://samvera.org
+  responsibility_statement: Western Carolina University Initial Profile
+  type: Hyku Profile with Western Carolina University Custom Work Types
+  version: 1
+classes:
+  GenericWorkResource:
+    display_label: Generic Worki461--up
+  ImageResource:
+    display_label: Image
+  OerResource:
+    display_label: OER
+  EtdResource:
+    display_label: ETD
+  AdminSetResource:
+    display_label: AdminSetResource
+  CollectionResource:
+    display_label: Collection Resource
+  Hyrax::FileSet:
+    display_label: FileSet
+  ScholarlyWork:
+    display_label: Scholarly Work
+  UncaWork:
+    display_label: Unca Work (obsolete)
+contexts:
+  flexible_context:
+    display_label: Flexible Metadata Example
+  special_context:
+    display_label: Special Context
+mappings:
+  blacklight:
+    name: Additional Blacklight Solr Mappings
+  metatags:
+    name: Metatags
+  mods_oai_pmh:
+    name: MODS OAI PMH
+  qualified_dc_pmh:
+    name: Qualified DC OAI PMH
+  simple_dc_pmh:
+    name: Simple DC OAI PMH
+properties:
+  title:
+    available_on:
+      class:
+        - AdminSetResource
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    definition:
+      default:
+        Enter a standardized title for display. If only one title is needed,
+        transcribe the title from the source itself.
+    display_label:
+      default: Title
+    index_documentation: displayable, searchable
+    indexing:
+      - title_sim
+      - title_tesim
+    form:
+      required: true
+      primary: true
+    mappings:
+      metatags: twitter:title, og:title
+      mods_oai_pmh: mods:titleInfo/mods:title
+      qualified_dc_pmh: dcterms:title
+      simple_dc_pmh: dc:title
+    property_uri: http://purl.org/dc/terms/title
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Pencil drawn portrait study of woman
+    view:
+      label:
+        en: "Title"
+        es: "Título"
+      html_dl: true
+  date_modified:
+    available_on:
+      class:
+        - AdminSetResource
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    display_label:
+      default: Date Modified
+    property_uri: http://purl.org/dc/terms/modified
+    range: http://www.w3.org/2001/XMLSchema#dateTime
+    sample_values:
+      - "2024-06-06 21:06:51 +0000"
+    view:
+      label:
+        de: "Zuletzt geändert"
+        en: "Last modified"
+        es: "Última modificación"
+        fr: "Dernière modification"
+        it: "Ultima modifica"
+        pt-BR: "Última modificação"
+        zh: "最新修改"
+      html_dl: true
+  date_uploaded:
+    available_on:
+      class:
+        - AdminSetResource
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    display_label:
+      default: Date Uploaded
+    property_uri: http://purl.org/dc/terms/dateSubmitted
+    range: http://www.w3.org/2001/XMLSchema#dateTime
+    sample_values:
+      - "2024-06-06 21:06:51 +0000"
+  depositor:
+    available_on:
+      class:
+        - AdminSetResource
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Depositor
+    index_documentation: searchable
+    indexing:
+      - depositor_tesim
+      - depositor_ssim
+    property_uri: http://id.loc.gov/vocabulary/relators/dpt
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Julie Allinson
+  creator:
+    available_on:
+      class:
+        - AdminSetResource
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Creator
+    index_documentation: displayable, searchable
+    indexing:
+      - creator_sim
+      - creator_tesim
+    form:
+      required: true
+      primary: true
+    property_uri: http://purl.org/dc/elements/1.1/creator
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Julie Allinson
+    view:
+      render_as: "faceted"
+      html_dl: true
+  license:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "licenses"
+    display_label:
+      default: License
+    index_documentation: displayable, searchable
+    indexing:
+      - license_sim
+      - license_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/license
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - http://creativecommons.org/licenses/by/3.0/us/
+    view:
+      render_as: "external_link"
+      html_dl: true
+  abstract:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Abstract
+    index_documentation: displayable, searchable
+    indexing:
+      - abstract_sim
+      - abstract_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/abstract
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - This is an abstract.
+    view:
+      html_dl: true
+  access_right:
+    available_on:
+      class:
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Access Right
+    index_documentation: displayable, searchable
+    indexing:
+      - access_right_sim
+      - access_right_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/accessRights
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Open Access
+    view:
+      html_dl: true
+  alternative_title:
+    available_on:
+      class:
+        - AdminSetResource
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Alternative Title
+    index_documentation: displayable, searchable
+    indexing:
+      - alternative_title_sim
+      - alternative_title_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/alternative
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Alternate Title Example
+    view:
+      label:
+        en: "Alternative Title"
+        es: "Título Alternativo"
+      html_dl: true
+  arkivo_checksum:
+    available_on:
+      class:
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Arkivo Checksum
+    form:
+      primary: false
+    property_uri: http://scholarsphere.psu.edu/ns#arkivoChecksum
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - c0855931b7f1aefedb91d31af76873c0
+  based_near:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Location
+    index_documentation: displayable, searchable
+    indexing:
+      - based_near_sim
+      - based_near_tesim
+    form:
+      primary: false
+    property_uri: http://xmlns.com/foaf/0.1/based_near
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - San Diego, California, United States
+    view:
+      label: Based Near
+      render_term: "based_near_label"
+      html_dl: true
+  bibliographic_citation:
+    available_on:
+      class:
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Bibliographic Citation
+    index_documentation: displayable, searchable
+    indexing:
+      - bibliographic_citation_sim
+      - bibliographic_citation_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/bibliographicCitation
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Doe, J. (2024). Example Citation. Journal of Examples, 12(3), 45-67.
+    view:
+      html_dl: true
+  contributor:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Contributor
+    index_documentation: displayable, searchable
+    indexing:
+      - contributor_tesim
+      - contributor_sim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/elements/1.1/contributor
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Julie Allinson
+    view:
+      render_as: "faceted"
+      html_dl: true
+  date_created:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#dateTime
+      sources:
+        - "null"
+    display_label:
+      default: Date Created
+    index_documentation: displayable, searchable
+    indexing:
+      - date_created_sim
+      - date_created_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/created
+    range: http://www.w3.org/2001/XMLSchema#dateTime
+    sample_values:
+      - "2024-06-06 21:06:51 +0000"
+    view:
+      render_as: "linked"
+      search_field: "date_created_tesim"
+      html_dl: true
+  date_published:
+    available_on:
+      class:
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#dateTime
+      sources:
+      - 'null'
+    display_label:
+      default: Date Published
+    index_documentation: displayable, searchable
+    indexing:
+      - date_published_sim
+      - date_published_tesim
+    form:
+      primary: true
+      required: false
+    property_uri: http://purl.org/dc/terms/dateAccepted
+    range: http://www.w3.org/2001/XMLSchema#dateTime
+    sample_values:
+    - '2024-06-06 21:06:51 +0000'
+    view:
+      html_dl: true
+  description:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Description
+    index_documentation: displayable, searchable
+    indexing:
+      - description_sim
+      - description_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/elements/1.1/description
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - This is a description.
+  identifier:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Identifier
+    index_documentation: displayable, searchable
+    indexing:
+      - identifier_sim
+      - identifier_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/identifier
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - abc123
+    view:
+      render_as: "linked"
+      search_field: "identifier_tesim"
+      html_dl: true
+  import_url:
+    available_on:
+      class:
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Import URL
+    property_uri: http://scholarsphere.psu.edu/ns#importUrl
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - http://example.com/resource1
+  keyword:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Keyword
+    index_documentation: displayable, searchable
+    indexing:
+      - keyword_sim
+      - keyword_tesim
+    form:
+      primary: false
+    property_uri: http://schema.org/keywords
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Metadata
+      - Repository
+    view:
+      render_as: "faceted"
+      html_dl: true
+  label:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Label
+    index_documentation: displayable, searchable
+    indexing:
+      - label_sim
+      - label_tesim
+    form:
+      primary: false
+    property_uri: info:fedora/fedora-system:def/model#downloadFilename
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - file_label.txt
+  language:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Language
+    index_documentation: displayable, searchable
+    indexing:
+      - language_sim
+      - language_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/elements/1.1/language
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - English
+      - Spanish
+    view:
+      render_as: "faceted"
+      html_dl: true
+  publisher:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Publisher
+    index_documentation: displayable, searchable
+    indexing:
+      - publisher_sim
+      - publisher_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/elements/1.1/publisher
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Scholastic
+    view:
+      render_as: "faceted"
+      html_dl: true
+  related_url:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Related URL
+    index_documentation: displayable, searchable
+    indexing:
+      - related_url_sim
+      - related_url_tesim
+    form:
+      primary: false
+    property_uri: http://www.w3.org/2000/01/rdf-schema#seeAlso
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - http://example.com/resource1
+    view:
+      render_as: "external_link"
+      html_dl: true
+  relative_path:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Relative Path
+    property_uri: http://scholarsphere.psu.edu/ns#relativePath
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "/path/to/resource"
+  resource_type:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "resource_types"
+    display_label:
+      default: Resource Type
+    index_documentation: displayable, searchable
+    indexing:
+      - resource_type_sim
+      - resource_type_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/type
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Article
+      - Conference Proceeding
+    view:
+      render_as: "faceted"
+      html_dl: true
+  rights_notes:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Rights Notes
+    index_documentation: displayable, searchable
+    indexing:
+      - rights_notes_sim
+      - rights_notes_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/elements/1.1/rights
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Creative Commons license.
+    view:
+      html_dl: true
+  rights_statement:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "rights_statements"
+    display_label:
+      default: Rights Statement
+    index_documentation: displayable, searchable
+    indexing:
+      - rights_statement_sim
+      - rights_statement_tesim
+    form:
+      primary: true
+      required: true
+    property_uri: http://www.europeana.eu/schemas/edm/rights
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - http://rightsstatements.org/vocab/InC/1.0/
+    view:
+      html_dl: true
+      render_as: "rights_statement"
+  source:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Source
+    index_documentation: displayable, searchable
+    indexing:
+      - source_sim
+      - source_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/source
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Original Manuscript
+      - Digital Archive
+    view:
+      html_dl: true
+  subject:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Subject
+    index_documentation: displayable, searchable
+    indexing:
+      - subject_sim
+      - subject_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/elements/1.1/subject
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Art
+      - Science
+    view:
+      render_as: "faceted"
+      html_dl: true
+  department:
+    available_on:
+      class:
+        - CollectionResource
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Department
+    form:
+      primary: true
+    property_uri: http://hyrax-example.com/department
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Mathematics
+      - History
+    view:
+      html_dl: true
+  course:
+    available_on:
+      class:
+        - CollectionResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Course
+    form:
+      primary: false
+    property_uri: http://hyrax-example.com/course
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Computer Science 50
+    view:
+      html_dl: true
+  format:
+    available_on:
+      class:
+        - EtdResource
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Format
+    index_documentation: searchable
+    indexing:
+      - "format_tesim"
+    form:
+      required: false
+      primary: false
+      multiple: true
+    property_uri: http://purl.org/dc/terms/format
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - PDF
+  # Image-specific metadata from image_resource.yaml
+  extent:
+    available_on:
+      class:
+        - ImageResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Extent
+    index_documentation: searchable
+    indexing:
+      - "extent_tesim"
+    form:
+      required: false
+      primary: false
+      multiple: true
+    property_uri: http://purl.org/dc/terms/extent
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "300 dpi"
+      - "1024x768 pixels"
+  # OER-specific metadata from oer_resource.yaml
+  accessibility_feature:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Accessibility Feature
+    index_documentation: displayable, searchable
+    indexing:
+      - "accessibility_feature_tesim"
+      - "accessibility_feature_sim"
+    form:
+      primary: false
+      multiple: true
+    property_uri: http://schema.org/accessibilityFeature
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Subtitles
+      - Audio Description
+      - Transcripts
+  accessibility_hazard:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Accessibility Hazard
+    index_documentation: displayable, searchable
+    indexing:
+      - "accessibility_hazard_tesim"
+      - "accessibility_hazard_sim"
+    form:
+      primary: false
+      multiple: true
+    property_uri: http://schema.org/accessibilityHazard
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Motion Simulation
+  accessibility_summary:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Accessibility Summary
+    index_documentation: displayable, searchable
+    indexing:
+      - "accessibility_summary_tesim"
+      - "accessibility_summary_sim"
+    form:
+      primary: false
+      multiple: false
+    property_uri: http://schema.org/accessibilitySummary
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - This resource includes subtitles for all video content.
+      - The resource provides text descriptions for all images.
+  admin_note:
+    available_on:
+      class:
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Admin Note
+    index_documentation: searchable
+    indexing:
+      - "admin_note_tesim"
+    form:
+      primary: false
+      multiple: false
+    property_uri: http://schema.org/positiveNotes
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - This is an admin note.
+      - Another example of an admin note.
+    view:
+      html_dl: true
+  additional_information:
+    available_on:
+      class:
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Additional Information
+    index_documentation: searchable
+    indexing:
+      - "additional_information_tesim"
+    form:
+      primary: false
+      multiple: true
+    property_uri: http://purl.org/dc/terms/accessRights
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - This is some additional information.
+      - More details and context.
+  alternate_version_id:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Alternate Version ID
+    index_documentation: displayable, searchable
+    indexing:
+      - "alternate_version_id_tesim"
+      - "alternate_version_id_sim"
+    property_uri: http://purl.org/dc/terms/hasVersion
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - alt_version_1
+      - alt_version_2
+  audience:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "audience"
+    display_label:
+      default: Audience
+    index_documentation: displayable, searchable
+    indexing:
+      - "audience_tesim"
+      - "audience_sim"
+    form:
+      required: true
+      primary: true
+    property_uri: http://schema.org/EducationalAudience
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Student
+      - Instructor
+    view:
+      html_dl: true
+      render_as: "faceted"
+  date:
+    available_on:
+      class:
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Date
+    index_documentation: displayable, searchable
+    indexing:
+      - "date_tesim"
+      - "date_sim"
+    property_uri: https://hykucommons.org/terms/date
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "2024-06-07"
+      - "2023-05-12"
+  discipline:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "discipline"
+    display_label:
+      default: Discipline
+    index_documentation: searchable
+    indexing:
+      - "discipline_tesim"
+    form:
+      required: true
+      primary: true
+    property_uri: https://hykucommons.org/terms/degree_discipline
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "Languages - Spanish"
+      - "Natural Sciences - Physics"
+    view:
+      html_dl: true
+      render_as: "faceted"
+  education_level:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "education_levels"
+    display_label:
+      default: Education Level
+    index_documentation: displayable, searchable
+    indexing:
+      - "education_level_tesim"
+      - "education_level_sim"
+    form:
+      required: true
+      primary: true
+    property_uri: http://purl.org/dc/terms/educationLevel
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "Community college / Lower division"
+      - "College / Upper division"
+    view:
+      html_dl: true
+      render_as: "faceted"
+  learning_resource_type:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "learning_resource_types"
+    display_label:
+      default: Learning Resource Type
+    index_documentation: displayable, searchable
+    indexing:
+      - "learning_resource_type_tesim"
+      - "learning_resource_type_sim"
+    form:
+      required: true
+      primary: true
+    property_uri: http://schema.org/learningResourceType
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "Activity/lab"
+      - "Assessment (test, quizzes, etc.)"
+    view:
+      html_dl: true
+      render_as: "faceted"
+  newer_version_id:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Newer Version ID
+    index_documentation: displayable, searchable
+    indexing:
+      - "newer_version_id_tesim"
+      - "newer_version_id_sim"
+    property_uri: http://purl.org/dc/terms/isReplacedBy
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - new_version_1
+      - new_version_2
+  oer_size:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: OER Size
+    index_documentation: searchable
+    indexing:
+      - "oer_size_tesim"
+    form:
+      primary: false
+      multiple: true
+    property_uri: http://purl.org/dc/terms/extent
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - 15MB
+      - 200 pages
+  previous_version_id:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Previous Version ID
+    index_documentation: displayable, searchable
+    indexing:
+      - "previous_version_id_tesim"
+      - "previous_version_id_sim"
+    property_uri: http://purl.org/dc/terms/replaces
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - prev_version_1
+      - prev_version_2
+  related_item_id:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Related Item ID
+    index_documentation: displayable, searchable
+    indexing:
+      - "related_item_id_tesim"
+      - "related_item_id_sim"
+    property_uri: http://purl.org/dc/terms/relation
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - related_item_1
+      - related_item_2
+  rights_holder:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Rights Holder
+    index_documentation: displayable, searchable
+    indexing:
+      - "rights_holder_tesim"
+      - "rights_holder_sim"
+    form:
+      primary: false
+      multiple: true
+    property_uri: http://purl.org/dc/terms/rightsHolder
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - John Doe
+      - Jane Smith
+  table_of_contents:
+    available_on:
+      class:
+        - OerResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Table of Contents
+    index_documentation: searchable
+    indexing:
+      - "table_of_contents_tesim"
+    form:
+      primary: false
+      multiple: true
+    property_uri: http://purl.org/dc/terms/tableOfContents
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "Chapter 1: Introduction"
+      - "Chapter 2: Literature Review"
+      - "Chapter 3: Methodology"
+  # ETD-specific metadata - etd_resource.yaml
+  advisor:
+    available_on:
+      class:
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Advisor
+    index_documentation: searchable
+    indexing:
+      - "advisor_tesim"
+    form:
+      required: false
+      primary: false
+      multiple: true
+    property_uri: https://hykucommons.org/terms/advisor
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Dr. John Doe
+      - Dr. Jane Smith
+  committee_member:
+    available_on:
+      class:
+        - EtdResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Committee Member
+    index_documentation: searchable
+    indexing:
+      - "committee_member_tesim"
+    form:
+      required: false
+      primary: false
+      multiple: true
+    property_uri: https://hykucommons.org/terms/committee_member
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Dr. John Doe
+      - Dr. Jane Smith
+  degree_name:
+    available_on:
+      class:
+        - EtdResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Degree Name
+    index_documentation: searchable
+    indexing:
+      - "degree_name_tesim"
+    form:
+      required: true
+      primary: true
+      multiple: true
+    property_uri: https://hykucommons.org/terms/degree_name
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Bachelor of Science
+      - Master of Arts
+    view:
+      html_dl: true
+  degree_level:
+    available_on:
+      class:
+        - EtdResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Degree Level
+    index_documentation: searchable
+    indexing:
+      - "degree_level_tesim"
+    form:
+      required: true
+      primary: true
+      multiple: true
+    property_uri: https://hykucommons.org/terms/degree_level
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Undergraduate
+      - Graduate
+    view:
+      html_dl: true
+  degree_discipline:
+    available_on:
+      class:
+        - EtdResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Degree Discipline
+    index_documentation: searchable
+    indexing:
+      - "degree_discipline_tesim"
+    form:
+      required: true
+      primary: true
+      multiple: true
+    property_uri: https://hykucommons.org/terms/degree_discipline
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Computer Science
+      - Biology
+    view:
+      html_dl: true
+  degree_grantor:
+    available_on:
+      class:
+        - EtdResource
+    cardinality:
+      minimum: 1
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Degree Grantor
+    index_documentation: searchable
+    indexing:
+      - "degree_grantor_tesim"
+    form:
+      required: true
+      primary: true
+      multiple: true
+    property_uri: https://hykucommons.org/terms/degree_grantor
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - University of Example
+      - Example State University
+    view:
+      html_dl: true
+  # ScholarlyWork specific metadata - scholarly_work.yaml
+  spatial_coverage:
+    available_on:
+      class:
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Coverage - Geographic name
+    index_documentation: searchable, displayable
+    indexing:
+      - spatial_coverage_sim
+      - spatial_coverage_tesim
+    form:
+      primary: true
+    property_uri: http://purl.org/dc/terms/spatial
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "North America"
+      - "Europe"
+    view:
+      html_dl: true
+  temporal_coverage:
+    available_on:
+      class:
+        - ScholarlyWork
+        - UncaWork
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Coverage - Historic era
+    index_documentation: searchable, displayable
+    indexing:
+      - temporal_coverage_sim
+      - temporal_coverage_tesim
+    form:
+      primary: true
+    property_uri: http://purl.org/dc/terms/temporal
+    range: http://www.w3.org/2001/XMLSchema#string
+    view:
+      html_dl: true
+    indexing:
+    - temporal_coverage_sim
+    - temporal_coverage_tesim
+  # Bulkrax metadata from bulkrax_metadata.yaml
+  bulkrax_identifier:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Bulkrax Identifier
+    index_documentation: displayable, searchable
+    indexing:
+      - "bulkrax_identifier_tesi"
+      - "bulkrax_identifier_ssi"
+    form:
+      display: false
+      primary: false
+      required: false
+      multiple: false
+    property_uri: https://hykucommons.org/terms/bulkrax_identifier
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - example-bulkrax-identifier
+  # PDF.js metadata from with_pdf_viewer.yaml
+  show_pdf_viewer:
+    available_on:
+      class:
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#bool
+      sources:
+        - "null"
+    display_label:
+      default: Show PDF Viewer
+    index_documentation: displayable, searchable
+    indexing:
+      - "show_pdf_viewer_bsi"
+    form:
+      display: false
+      primary: false
+      required: false
+      multiple: false
+    property_uri: http://id.loc.gov/vocabulary/identifiers/show_pdf_viewer
+    range: http://www.w3.org/2001/XMLSchema#bool
+    sample_values:
+      - "0"
+      - "1"
+  show_pdf_download_button:
+    available_on:
+      class:
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#bool
+      sources:
+        - "null"
+    display_label:
+      default: Show PDF Download Button
+    index_documentation: displayable, searchable
+    indexing:
+      - "show_pdf_download_button_bsi"
+    form:
+      display: false
+      primary: false
+      required: false
+      multiple: false
+    property_uri: http://id.loc.gov/vocabulary/identifiers/show_pdf_download_button
+    range: http://www.w3.org/2001/XMLSchema#bool
+    sample_values:
+      - "0"
+      - "1"
+  # Video Embed metadata - with_video_embed.yaml
+  video_embed:
+    available_on:
+      class:
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Video Embed
+    index_documentation: searchable
+    indexing:
+      - "video_embed_tesi"
+    form:
+      display: true
+      primary: false
+      required: false
+      multiple: false
+    property_uri: https://atla.com/terms/video_embed
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - "https://player.vimeo.com/video/467264493?h=b089de0eab"
+      - "https://www.youtube.com/embed/Znf73dsFdC8"
+  # IiifPrint metadata - child_works_from_pdf_splitting.yaml
+  is_child:
+    available_on:
+      class:
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#bool
+      sources:
+        - "null"
+    display_label:
+      default: Is Child
+    index_documentation: displayable, searchable
+    indexing:
+      - "is_child_bsi"
+    form:
+      display: false
+      required: false
+      primary: false
+      multiple: false
+    property_uri: http://id.loc.gov/vocabulary/identifiers/isChild
+    range: http://www.w3.org/2001/XMLSchema#bool
+    sample_values:
+      - true
+      - false
+  split_from_pdf_id:
+    available_on:
+      class:
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Split from PDF ID
+    index_documentation: searchable
+    indexing:
+      - "split_from_pdf_id_ssi"
+    form:
+      display: false
+      required: false
+      primary: false
+      multiple: false
+    property_uri: http://id.loc.gov/vocabulary/identifiers/splitFromPdfId
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - example-split-from-pdf-id
+  # Special context metadata
+  dimensions:
+    available_on:
+      class:
+        - ImageResource
+      context:
+        - special_context
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Dimensions
+    index_documentation: displayable, searchable
+    indexing:
+      - dimensions_sim
+      - dimensions_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/format
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - 50" x 20"
+      - 5 m x 10 m x 8 m
+    view:
+      render_as: "faceted"
+      html_dl: true
+  hide_from_catalog_search:
+    available_on:
+      class:
+        - CollectionResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#bool
+      sources:
+        - "null"
+    display_label:
+      default: Hide from Catalog Search
+    index_documentation: displayable, searchable
+    indexing:
+      - hide_from_catalog_search_bsi
+      - hide_from_catalog_search_tesim
+    form:
+      display: false
+      primary: false
+      required: false
+      multiple: false
+    property_uri: https://hykucommons.org/terms/hide_from_catalog_search
+    range: http://www.w3.org/2001/XMLSchema#bool
+    sample_values:
+      - true
+      - false

--- a/spec/controllers/admin/work_types_controller_decorator_spec.rb
+++ b/spec/controllers/admin/work_types_controller_decorator_spec.rb
@@ -58,5 +58,46 @@ RSpec.describe Admin::WorkTypesController, singletenant: true do
         end
       end
     end
+
+    describe "tenant_excluded_work_types" do
+      context "for UNCA tenant" do
+        before do
+          allow(Apartment::Tenant).to receive(:current).and_return('unca')
+          account = double('Account', cname: 'unca.hykuup.com')
+          allow(Account).to receive(:find_by).with(tenant: 'unca').and_return(account)
+        end
+        
+        it "returns only MobiusWork as excluded" do
+          excluded_types = controller_instance.send(:tenant_excluded_work_types)
+          expect(excluded_types).to eq(%w[MobiusWork])
+        end
+      end
+      
+      context "for Mobius tenant" do
+        before do
+          allow(Apartment::Tenant).to receive(:current).and_return('mobius')
+          account = double('Account', cname: 'example.digitalmobius.org')
+          allow(Account).to receive(:find_by).with(tenant: 'mobius').and_return(account)
+        end
+        
+        it "returns UncaWork and ScholarlyWork as excluded" do
+          excluded_types = controller_instance.send(:tenant_excluded_work_types)
+          expect(excluded_types).to eq(%w[UncaWork ScholarlyWork])
+        end
+      end
+      
+      context "for generic tenant" do
+        before do
+          allow(Apartment::Tenant).to receive(:current).and_return('generic')
+          account = double('Account', cname: 'example.com')
+          allow(Account).to receive(:find_by).with(tenant: 'generic').and_return(account)
+        end
+        
+        it "returns all tenant-specific work types as excluded" do
+          excluded_types = controller_instance.send(:tenant_excluded_work_types)
+          expect(excluded_types).to eq(%w[MobiusWork UncaWork ScholarlyWork])
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/admin/work_types_controller_decorator_spec.rb
+++ b/spec/controllers/admin/work_types_controller_decorator_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe Admin::WorkTypesController, singletenant: true do
   describe "tenant-specific work type filtering" do
     let(:admin_user) { create(:admin) }
     let(:controller_instance) { described_class.new }
-    
+
     before do
       # Ensure all work types are registered
       allow(Hyrax.config).to receive(:registered_curation_concern_types).and_return([
-        'GenericWork', 'Image', 'Etd', 'Oer', 'MobiusWork', 'UncaWork', 'ScholarlyWork'
-      ])
+                                                                                      'GenericWork', 'Image', 'Etd', 'Oer', 'MobiusWork', 'UncaWork', 'ScholarlyWork'
+                                                                                    ])
     end
-    
+
     describe "tenant_allowed_work_types" do
       context "for UNCA tenant" do
         before do
@@ -19,40 +19,40 @@ RSpec.describe Admin::WorkTypesController, singletenant: true do
           account = double('Account', cname: 'unca.hykuup.com')
           allow(Account).to receive(:find_by).with(tenant: 'unca').and_return(account)
         end
-        
+
         it "excludes MobiusWork" do
           allowed_types = TenantWorkTypeFilter.allowed_work_types
-          
+
           expect(allowed_types).to include('GenericWork', 'Image', 'Etd', 'Oer', 'ScholarlyWork', 'UncaWork')
           expect(allowed_types).not_to include('MobiusWork')
         end
       end
-      
+
       context "for Mobius tenant" do
         before do
           allow(Apartment::Tenant).to receive(:current).and_return('mobius')
           account = double('Account', cname: 'example.digitalmobius.org')
           allow(Account).to receive(:find_by).with(tenant: 'mobius').and_return(account)
         end
-        
+
         it "excludes UncaWork and ScholarlyWork" do
           allowed_types = TenantWorkTypeFilter.allowed_work_types
-          
+
           expect(allowed_types).to include('GenericWork', 'Image', 'Etd', 'Oer', 'MobiusWork')
           expect(allowed_types).not_to include('UncaWork', 'ScholarlyWork')
         end
       end
-      
+
       context "for generic tenant" do
         before do
           allow(Apartment::Tenant).to receive(:current).and_return('generic')
           account = double('Account', cname: 'example.com')
           allow(Account).to receive(:find_by).with(tenant: 'generic').and_return(account)
         end
-        
+
         it "excludes all tenant-specific work types" do
           allowed_types = TenantWorkTypeFilter.allowed_work_types
-          
+
           expect(allowed_types).to include('GenericWork', 'Image', 'Etd', 'Oer')
           expect(allowed_types).not_to include('MobiusWork', 'UncaWork', 'ScholarlyWork')
         end
@@ -66,33 +66,33 @@ RSpec.describe Admin::WorkTypesController, singletenant: true do
           account = double('Account', cname: 'unca.hykuup.com')
           allow(Account).to receive(:find_by).with(tenant: 'unca').and_return(account)
         end
-        
+
         it "returns only MobiusWork as excluded" do
           excluded_types = TenantWorkTypeFilter.excluded_work_types
           expect(excluded_types).to eq(%w[MobiusWork])
         end
       end
-      
+
       context "for Mobius tenant" do
         before do
           allow(Apartment::Tenant).to receive(:current).and_return('mobius')
           account = double('Account', cname: 'example.digitalmobius.org')
           allow(Account).to receive(:find_by).with(tenant: 'mobius').and_return(account)
         end
-        
+
         it "returns UncaWork and ScholarlyWork as excluded" do
           excluded_types = TenantWorkTypeFilter.excluded_work_types
           expect(excluded_types).to eq(%w[UncaWork ScholarlyWork])
         end
       end
-      
+
       context "for generic tenant" do
         before do
           allow(Apartment::Tenant).to receive(:current).and_return('generic')
           account = double('Account', cname: 'example.com')
           allow(Account).to receive(:find_by).with(tenant: 'generic').and_return(account)
         end
-        
+
         it "returns all tenant-specific work types as excluded" do
           excluded_types = TenantWorkTypeFilter.excluded_work_types
           expect(excluded_types).to eq(%w[MobiusWork UncaWork ScholarlyWork])

--- a/spec/controllers/admin/work_types_controller_decorator_spec.rb
+++ b/spec/controllers/admin/work_types_controller_decorator_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.describe Admin::WorkTypesController, singletenant: true do
+  describe "tenant-specific work type filtering" do
+    let(:admin_user) { create(:admin) }
+    let(:controller_instance) { described_class.new }
+    
+    before do
+      # Ensure all work types are registered
+      allow(Hyrax.config).to receive(:registered_curation_concern_types).and_return([
+        'GenericWork', 'Image', 'Etd', 'Oer', 'MobiusWork', 'UncaWork', 'ScholarlyWork'
+      ])
+    end
+    
+    describe "tenant_allowed_work_types" do
+      context "for UNCA tenant" do
+        before do
+          allow(Apartment::Tenant).to receive(:current).and_return('unca')
+          account = double('Account', cname: 'unca.hykuup.com')
+          allow(Account).to receive(:find_by).with(tenant: 'unca').and_return(account)
+        end
+        
+        it "excludes MobiusWork" do
+          allowed_types = controller_instance.send(:tenant_allowed_work_types)
+          
+          expect(allowed_types).to include('GenericWork', 'Image', 'Etd', 'Oer', 'ScholarlyWork', 'UncaWork')
+          expect(allowed_types).not_to include('MobiusWork')
+        end
+      end
+      
+      context "for Mobius tenant" do
+        before do
+          allow(Apartment::Tenant).to receive(:current).and_return('mobius')
+          account = double('Account', cname: 'example.digitalmobius.org')
+          allow(Account).to receive(:find_by).with(tenant: 'mobius').and_return(account)
+        end
+        
+        it "excludes UncaWork and ScholarlyWork" do
+          allowed_types = controller_instance.send(:tenant_allowed_work_types)
+          
+          expect(allowed_types).to include('GenericWork', 'Image', 'Etd', 'Oer', 'MobiusWork')
+          expect(allowed_types).not_to include('UncaWork', 'ScholarlyWork')
+        end
+      end
+      
+      context "for generic tenant" do
+        before do
+          allow(Apartment::Tenant).to receive(:current).and_return('generic')
+          account = double('Account', cname: 'example.com')
+          allow(Account).to receive(:find_by).with(tenant: 'generic').and_return(account)
+        end
+        
+        it "excludes all tenant-specific work types" do
+          allowed_types = controller_instance.send(:tenant_allowed_work_types)
+          
+          expect(allowed_types).to include('GenericWork', 'Image', 'Etd', 'Oer')
+          expect(allowed_types).not_to include('MobiusWork', 'UncaWork', 'ScholarlyWork')
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/work_types_controller_decorator_spec.rb
+++ b/spec/controllers/admin/work_types_controller_decorator_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Admin::WorkTypesController, singletenant: true do
         end
         
         it "excludes MobiusWork" do
-          allowed_types = controller_instance.send(:tenant_allowed_work_types)
+          allowed_types = TenantWorkTypeFilter.allowed_work_types
           
           expect(allowed_types).to include('GenericWork', 'Image', 'Etd', 'Oer', 'ScholarlyWork', 'UncaWork')
           expect(allowed_types).not_to include('MobiusWork')
@@ -36,7 +36,7 @@ RSpec.describe Admin::WorkTypesController, singletenant: true do
         end
         
         it "excludes UncaWork and ScholarlyWork" do
-          allowed_types = controller_instance.send(:tenant_allowed_work_types)
+          allowed_types = TenantWorkTypeFilter.allowed_work_types
           
           expect(allowed_types).to include('GenericWork', 'Image', 'Etd', 'Oer', 'MobiusWork')
           expect(allowed_types).not_to include('UncaWork', 'ScholarlyWork')
@@ -51,7 +51,7 @@ RSpec.describe Admin::WorkTypesController, singletenant: true do
         end
         
         it "excludes all tenant-specific work types" do
-          allowed_types = controller_instance.send(:tenant_allowed_work_types)
+          allowed_types = TenantWorkTypeFilter.allowed_work_types
           
           expect(allowed_types).to include('GenericWork', 'Image', 'Etd', 'Oer')
           expect(allowed_types).not_to include('MobiusWork', 'UncaWork', 'ScholarlyWork')
@@ -68,7 +68,7 @@ RSpec.describe Admin::WorkTypesController, singletenant: true do
         end
         
         it "returns only MobiusWork as excluded" do
-          excluded_types = controller_instance.send(:tenant_excluded_work_types)
+          excluded_types = TenantWorkTypeFilter.excluded_work_types
           expect(excluded_types).to eq(%w[MobiusWork])
         end
       end
@@ -81,7 +81,7 @@ RSpec.describe Admin::WorkTypesController, singletenant: true do
         end
         
         it "returns UncaWork and ScholarlyWork as excluded" do
-          excluded_types = controller_instance.send(:tenant_excluded_work_types)
+          excluded_types = TenantWorkTypeFilter.excluded_work_types
           expect(excluded_types).to eq(%w[UncaWork ScholarlyWork])
         end
       end
@@ -94,7 +94,7 @@ RSpec.describe Admin::WorkTypesController, singletenant: true do
         end
         
         it "returns all tenant-specific work types as excluded" do
-          excluded_types = controller_instance.send(:tenant_excluded_work_types)
+          excluded_types = TenantWorkTypeFilter.excluded_work_types
           expect(excluded_types).to eq(%w[MobiusWork UncaWork ScholarlyWork])
         end
       end

--- a/spec/controllers/hyrax/metadata_profiles_controller_decorator_spec.rb
+++ b/spec/controllers/hyrax/metadata_profiles_controller_decorator_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe Hyrax::MetadataProfilesController, singletenant: true do
         end
         
         it "returns all work types except MobiusWork" do
-          allowed_types = controller_instance.send(:tenant_allowed_work_types)
+          allowed_types = TenantWorkTypeFilter.allowed_work_types
           
           expect(allowed_types).to include('GenericWork', 'Image', 'Etd', 'Oer', 'UncaWork', 'ScholarlyWork')
           expect(allowed_types).not_to include('MobiusWork')
@@ -198,7 +198,7 @@ RSpec.describe Hyrax::MetadataProfilesController, singletenant: true do
         end
         
         it "returns all work types except UncaWork and ScholarlyWork" do
-          allowed_types = controller_instance.send(:tenant_allowed_work_types)
+          allowed_types = TenantWorkTypeFilter.allowed_work_types
           
           expect(allowed_types).to include('GenericWork', 'Image', 'Etd', 'Oer', 'MobiusWork')
           expect(allowed_types).not_to include('UncaWork', 'ScholarlyWork')
@@ -213,7 +213,7 @@ RSpec.describe Hyrax::MetadataProfilesController, singletenant: true do
         end
         
         it "returns only generic work types" do
-          allowed_types = controller_instance.send(:tenant_allowed_work_types)
+          allowed_types = TenantWorkTypeFilter.allowed_work_types
           
           expect(allowed_types).to include('GenericWork', 'Image', 'Etd', 'Oer')
           expect(allowed_types).not_to include('MobiusWork', 'UncaWork', 'ScholarlyWork')

--- a/spec/controllers/hyrax/metadata_profiles_controller_decorator_spec.rb
+++ b/spec/controllers/hyrax/metadata_profiles_controller_decorator_spec.rb
@@ -3,14 +3,14 @@
 RSpec.describe Hyrax::MetadataProfilesController, singletenant: true do
   describe "tenant-specific profile validation" do
     let(:controller_instance) { described_class.new }
-    
+
     before do
       # Ensure all work types are registered
       allow(Hyrax.config).to receive(:registered_curation_concern_types).and_return([
-        'GenericWork', 'Image', 'Etd', 'Oer', 'MobiusWork', 'UncaWork', 'ScholarlyWork'
-      ])
+                                                                                      'GenericWork', 'Image', 'Etd', 'Oer', 'MobiusWork', 'UncaWork', 'ScholarlyWork'
+                                                                                    ])
     end
-    
+
     describe "validate_tenant_work_types!" do
       context "for UNCA tenant" do
         before do
@@ -18,7 +18,7 @@ RSpec.describe Hyrax::MetadataProfilesController, singletenant: true do
           account = double('Account', cname: 'unca.hykuup.com')
           allow(Account).to receive(:find_by).with(tenant: 'unca').and_return(account)
         end
-        
+
         it "allows profiles with UNCA-allowed work types" do
           profile_data = {
             'classes' => {
@@ -27,10 +27,10 @@ RSpec.describe Hyrax::MetadataProfilesController, singletenant: true do
               'ScholarlyWorkResource' => {}
             }
           }
-          
+
           expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }.not_to raise_error
         end
-        
+
         it "rejects profiles with MobiusWork and provides helpful error message" do
           profile_data = {
             'classes' => {
@@ -38,30 +38,30 @@ RSpec.describe Hyrax::MetadataProfilesController, singletenant: true do
               'MobiusWorkResource' => {}
             }
           }
-          
+
           expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }
             .to raise_error(StandardError, /This profile contains work types \(MobiusWork\) that are not allowed for unca\.hykuup\.com/)
         end
-        
+
         it "includes allowed work types in error message" do
           profile_data = {
             'classes' => {
               'MobiusWorkResource' => {}
             }
           }
-          
+
           expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }
             .to raise_error(StandardError, /Allowed work types for unca\.hykuup\.com: GenericWork, Image, Etd, Oer, UncaWork, ScholarlyWork/)
         end
       end
-      
+
       context "for Mobius tenant" do
         before do
           allow(Apartment::Tenant).to receive(:current).and_return('mobius')
           account = double('Account', cname: 'example.digitalmobius.org')
           allow(Account).to receive(:find_by).with(tenant: 'mobius').and_return(account)
         end
-        
+
         it "allows profiles with Mobius-allowed work types" do
           profile_data = {
             'classes' => {
@@ -69,10 +69,10 @@ RSpec.describe Hyrax::MetadataProfilesController, singletenant: true do
               'MobiusWorkResource' => {}
             }
           }
-          
+
           expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }.not_to raise_error
         end
-        
+
         it "rejects profiles with UncaWork and ScholarlyWork" do
           profile_data = {
             'classes' => {
@@ -81,30 +81,30 @@ RSpec.describe Hyrax::MetadataProfilesController, singletenant: true do
               'ScholarlyWorkResource' => {}
             }
           }
-          
+
           expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }
             .to raise_error(StandardError, /This profile contains work types \(UncaWork, ScholarlyWork\) that are not allowed for example\.digitalmobius\.org/)
         end
-        
+
         it "includes allowed work types in error message" do
           profile_data = {
             'classes' => {
               'UncaWorkResource' => {}
             }
           }
-          
+
           expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }
             .to raise_error(StandardError, /Allowed work types for example\.digitalmobius\.org: GenericWork, Image, Etd, Oer, MobiusWork/)
         end
       end
-      
+
       context "for generic tenant" do
         before do
           allow(Apartment::Tenant).to receive(:current).and_return('generic')
           account = double('Account', cname: 'dev-hykuup-knapsack.localhost.direct')
           allow(Account).to receive(:find_by).with(tenant: 'generic').and_return(account)
         end
-        
+
         it "allows profiles with only generic work types" do
           profile_data = {
             'classes' => {
@@ -114,10 +114,10 @@ RSpec.describe Hyrax::MetadataProfilesController, singletenant: true do
               'OerResource' => {}
             }
           }
-          
+
           expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }.not_to raise_error
         end
-        
+
         it "rejects profiles with any tenant-specific work types" do
           profile_data = {
             'classes' => {
@@ -127,53 +127,53 @@ RSpec.describe Hyrax::MetadataProfilesController, singletenant: true do
               'ScholarlyWorkResource' => {}
             }
           }
-          
+
           expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }
             .to raise_error(StandardError, /This profile contains work types \(MobiusWork, UncaWork, ScholarlyWork\) that are not allowed for dev-hykuup-knapsack\.localhost\.direct/)
         end
-        
+
         it "includes allowed work types in error message" do
           profile_data = {
             'classes' => {
               'MobiusWorkResource' => {}
             }
           }
-          
+
           expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }
             .to raise_error(StandardError, /Allowed work types for dev-hykuup-knapsack\.localhost\.direct: GenericWork, Image, Etd, Oer/)
         end
       end
-      
+
       context "when tenant name is not available" do
         before do
           allow(Apartment::Tenant).to receive(:current).and_return(nil)
           allow(Account).to receive(:find_by).with(tenant: nil).and_return(nil)
         end
-        
+
         it "uses fallback tenant name in error message" do
           profile_data = {
             'classes' => {
               'MobiusWorkResource' => {}
             }
           }
-          
+
           expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }
             .to raise_error(StandardError, /This profile contains work types \(MobiusWork\) that are not allowed for this tenant/)
         end
-        
+
         it "includes allowed work types in error message with fallback tenant name" do
           profile_data = {
             'classes' => {
               'MobiusWorkResource' => {}
             }
           }
-          
+
           expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }
             .to raise_error(StandardError, /Allowed work types for this tenant: GenericWork, Image, Etd, Oer/)
         end
       end
     end
-    
+
     describe "tenant_allowed_work_types" do
       context "for UNCA tenant" do
         before do
@@ -181,40 +181,40 @@ RSpec.describe Hyrax::MetadataProfilesController, singletenant: true do
           account = double('Account', cname: 'unca.hykuup.com')
           allow(Account).to receive(:find_by).with(tenant: 'unca').and_return(account)
         end
-        
+
         it "returns all work types except MobiusWork" do
           allowed_types = TenantWorkTypeFilter.allowed_work_types
-          
+
           expect(allowed_types).to include('GenericWork', 'Image', 'Etd', 'Oer', 'UncaWork', 'ScholarlyWork')
           expect(allowed_types).not_to include('MobiusWork')
         end
       end
-      
+
       context "for Mobius tenant" do
         before do
           allow(Apartment::Tenant).to receive(:current).and_return('mobius')
           account = double('Account', cname: 'example.digitalmobius.org')
           allow(Account).to receive(:find_by).with(tenant: 'mobius').and_return(account)
         end
-        
+
         it "returns all work types except UncaWork and ScholarlyWork" do
           allowed_types = TenantWorkTypeFilter.allowed_work_types
-          
+
           expect(allowed_types).to include('GenericWork', 'Image', 'Etd', 'Oer', 'MobiusWork')
           expect(allowed_types).not_to include('UncaWork', 'ScholarlyWork')
         end
       end
-      
+
       context "for generic tenant" do
         before do
           allow(Apartment::Tenant).to receive(:current).and_return('generic')
           account = double('Account', cname: 'example.com')
           allow(Account).to receive(:find_by).with(tenant: 'generic').and_return(account)
         end
-        
+
         it "returns only generic work types" do
           allowed_types = TenantWorkTypeFilter.allowed_work_types
-          
+
           expect(allowed_types).to include('GenericWork', 'Image', 'Etd', 'Oer')
           expect(allowed_types).not_to include('MobiusWork', 'UncaWork', 'ScholarlyWork')
         end

--- a/spec/controllers/hyrax/metadata_profiles_controller_decorator_spec.rb
+++ b/spec/controllers/hyrax/metadata_profiles_controller_decorator_spec.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::MetadataProfilesController, singletenant: true do
+  describe "tenant-specific profile validation" do
+    let(:controller_instance) { described_class.new }
+    
+    before do
+      # Ensure all work types are registered
+      allow(Hyrax.config).to receive(:registered_curation_concern_types).and_return([
+        'GenericWork', 'Image', 'Etd', 'Oer', 'MobiusWork', 'UncaWork', 'ScholarlyWork'
+      ])
+    end
+    
+    describe "validate_tenant_work_types!" do
+      context "for UNCA tenant" do
+        before do
+          allow(Apartment::Tenant).to receive(:current).and_return('unca')
+          account = double('Account', cname: 'unca.hykuup.com')
+          allow(Account).to receive(:find_by).with(tenant: 'unca').and_return(account)
+        end
+        
+        it "allows profiles with UNCA-allowed work types" do
+          profile_data = {
+            'classes' => {
+              'GenericWorkResource' => {},
+              'UncaWorkResource' => {},
+              'ScholarlyWorkResource' => {}
+            }
+          }
+          
+          expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }.not_to raise_error
+        end
+        
+        it "rejects profiles with MobiusWork and provides helpful error message" do
+          profile_data = {
+            'classes' => {
+              'GenericWorkResource' => {},
+              'MobiusWorkResource' => {}
+            }
+          }
+          
+          expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }
+            .to raise_error(StandardError, /This profile contains work types \(MobiusWork\) that are not allowed for unca\.hykuup\.com/)
+        end
+        
+        it "includes allowed work types in error message" do
+          profile_data = {
+            'classes' => {
+              'MobiusWorkResource' => {}
+            }
+          }
+          
+          expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }
+            .to raise_error(StandardError, /Allowed work types for unca\.hykuup\.com: GenericWork, Image, Etd, Oer, UncaWork, ScholarlyWork/)
+        end
+      end
+      
+      context "for Mobius tenant" do
+        before do
+          allow(Apartment::Tenant).to receive(:current).and_return('mobius')
+          account = double('Account', cname: 'example.digitalmobius.org')
+          allow(Account).to receive(:find_by).with(tenant: 'mobius').and_return(account)
+        end
+        
+        it "allows profiles with Mobius-allowed work types" do
+          profile_data = {
+            'classes' => {
+              'GenericWorkResource' => {},
+              'MobiusWorkResource' => {}
+            }
+          }
+          
+          expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }.not_to raise_error
+        end
+        
+        it "rejects profiles with UncaWork and ScholarlyWork" do
+          profile_data = {
+            'classes' => {
+              'GenericWorkResource' => {},
+              'UncaWorkResource' => {},
+              'ScholarlyWorkResource' => {}
+            }
+          }
+          
+          expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }
+            .to raise_error(StandardError, /This profile contains work types \(UncaWork, ScholarlyWork\) that are not allowed for example\.digitalmobius\.org/)
+        end
+        
+        it "includes allowed work types in error message" do
+          profile_data = {
+            'classes' => {
+              'UncaWorkResource' => {}
+            }
+          }
+          
+          expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }
+            .to raise_error(StandardError, /Allowed work types for example\.digitalmobius\.org: GenericWork, Image, Etd, Oer, MobiusWork/)
+        end
+      end
+      
+      context "for generic tenant" do
+        before do
+          allow(Apartment::Tenant).to receive(:current).and_return('generic')
+          account = double('Account', cname: 'dev-hykuup-knapsack.localhost.direct')
+          allow(Account).to receive(:find_by).with(tenant: 'generic').and_return(account)
+        end
+        
+        it "allows profiles with only generic work types" do
+          profile_data = {
+            'classes' => {
+              'GenericWorkResource' => {},
+              'ImageResource' => {},
+              'EtdResource' => {},
+              'OerResource' => {}
+            }
+          }
+          
+          expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }.not_to raise_error
+        end
+        
+        it "rejects profiles with any tenant-specific work types" do
+          profile_data = {
+            'classes' => {
+              'GenericWorkResource' => {},
+              'MobiusWorkResource' => {},
+              'UncaWorkResource' => {},
+              'ScholarlyWorkResource' => {}
+            }
+          }
+          
+          expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }
+            .to raise_error(StandardError, /This profile contains work types \(MobiusWork, UncaWork, ScholarlyWork\) that are not allowed for dev-hykuup-knapsack\.localhost\.direct/)
+        end
+        
+        it "includes allowed work types in error message" do
+          profile_data = {
+            'classes' => {
+              'MobiusWorkResource' => {}
+            }
+          }
+          
+          expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }
+            .to raise_error(StandardError, /Allowed work types for dev-hykuup-knapsack\.localhost\.direct: GenericWork, Image, Etd, Oer/)
+        end
+      end
+      
+      context "when tenant name is not available" do
+        before do
+          allow(Apartment::Tenant).to receive(:current).and_return(nil)
+          allow(Account).to receive(:find_by).with(tenant: nil).and_return(nil)
+        end
+        
+        it "uses fallback tenant name in error message" do
+          profile_data = {
+            'classes' => {
+              'MobiusWorkResource' => {}
+            }
+          }
+          
+          expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }
+            .to raise_error(StandardError, /This profile contains work types \(MobiusWork\) that are not allowed for this tenant/)
+        end
+        
+        it "includes allowed work types in error message with fallback tenant name" do
+          profile_data = {
+            'classes' => {
+              'MobiusWorkResource' => {}
+            }
+          }
+          
+          expect { controller_instance.send(:validate_tenant_work_types!, profile_data) }
+            .to raise_error(StandardError, /Allowed work types for this tenant: GenericWork, Image, Etd, Oer/)
+        end
+      end
+    end
+    
+    describe "tenant_allowed_work_types" do
+      context "for UNCA tenant" do
+        before do
+          allow(Apartment::Tenant).to receive(:current).and_return('unca')
+          account = double('Account', cname: 'unca.hykuup.com')
+          allow(Account).to receive(:find_by).with(tenant: 'unca').and_return(account)
+        end
+        
+        it "returns all work types except MobiusWork" do
+          allowed_types = controller_instance.send(:tenant_allowed_work_types)
+          
+          expect(allowed_types).to include('GenericWork', 'Image', 'Etd', 'Oer', 'UncaWork', 'ScholarlyWork')
+          expect(allowed_types).not_to include('MobiusWork')
+        end
+      end
+      
+      context "for Mobius tenant" do
+        before do
+          allow(Apartment::Tenant).to receive(:current).and_return('mobius')
+          account = double('Account', cname: 'example.digitalmobius.org')
+          allow(Account).to receive(:find_by).with(tenant: 'mobius').and_return(account)
+        end
+        
+        it "returns all work types except UncaWork and ScholarlyWork" do
+          allowed_types = controller_instance.send(:tenant_allowed_work_types)
+          
+          expect(allowed_types).to include('GenericWork', 'Image', 'Etd', 'Oer', 'MobiusWork')
+          expect(allowed_types).not_to include('UncaWork', 'ScholarlyWork')
+        end
+      end
+      
+      context "for generic tenant" do
+        before do
+          allow(Apartment::Tenant).to receive(:current).and_return('generic')
+          account = double('Account', cname: 'example.com')
+          allow(Account).to receive(:find_by).with(tenant: 'generic').and_return(account)
+        end
+        
+        it "returns only generic work types" do
+          allowed_types = controller_instance.send(:tenant_allowed_work_types)
+          
+          expect(allowed_types).to include('GenericWork', 'Image', 'Etd', 'Oer')
+          expect(allowed_types).not_to include('MobiusWork', 'UncaWork', 'ScholarlyWork')
+        end
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/quick_classification_query_decorator_spec.rb
+++ b/spec/services/hyrax/quick_classification_query_decorator_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::QuickClassificationQuery, singletenant: true do
+  describe "tenant-specific work type filtering for work creation" do
+    let(:user) { create(:user) }
+    
+    before do
+      # Ensure all work types are registered
+      allow(Hyrax.config).to receive(:registered_curation_concern_types).and_return([
+        'GenericWork', 'Image', 'Etd', 'Oer', 'MobiusWork', 'UncaWork', 'ScholarlyWork'
+      ])
+      
+      # Mock user permissions to allow creation of all work types
+      allow(user).to receive(:can?).with(:create, anything).and_return(true)
+    end
+    
+    describe "tenant filtering" do
+      context "for UNCA tenant" do
+        before do
+          allow(Apartment::Tenant).to receive(:current).and_return('unca')
+          account = double('Account', cname: 'unca.hykuup.com')
+          allow(Account).to receive(:find_by).with(tenant: 'unca').and_return(account)
+        end
+        
+        it "excludes MobiusWork from work creation options" do
+          query = described_class.new(user)
+          authorized_models = query.authorized_models
+          
+          expect(authorized_models.map(&:name)).to include('GenericWork', 'Image', 'Etd', 'Oer', 'ScholarlyWork', 'UncaWork')
+          expect(authorized_models.map(&:name)).not_to include('MobiusWork')
+        end
+      end
+      
+      context "for Mobius tenant" do
+        before do
+          allow(Apartment::Tenant).to receive(:current).and_return('mobius')
+          account = double('Account', cname: 'example.digitalmobius.org')
+          allow(Account).to receive(:find_by).with(tenant: 'mobius').and_return(account)
+        end
+        
+        it "excludes UncaWork and ScholarlyWork from work creation options" do
+          query = described_class.new(user)
+          authorized_models = query.authorized_models
+          
+          expect(authorized_models.map(&:name)).to include('GenericWork', 'Image', 'Etd', 'Oer', 'MobiusWork')
+          expect(authorized_models.map(&:name)).not_to include('UncaWork', 'ScholarlyWork')
+        end
+      end
+      
+      context "for generic tenant" do
+        before do
+          allow(Apartment::Tenant).to receive(:current).and_return('generic')
+          account = double('Account', cname: 'example.com')
+          allow(Account).to receive(:find_by).with(tenant: 'generic').and_return(account)
+        end
+        
+        it "excludes all tenant-specific work types from work creation options" do
+          query = described_class.new(user)
+          authorized_models = query.authorized_models
+          
+          expect(authorized_models.map(&:name)).to include('GenericWork', 'Image', 'Etd', 'Oer')
+          expect(authorized_models.map(&:name)).not_to include('MobiusWork', 'UncaWork', 'ScholarlyWork')
+        end
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/quick_classification_query_decorator_spec.rb
+++ b/spec/services/hyrax/quick_classification_query_decorator_spec.rb
@@ -3,17 +3,17 @@
 RSpec.describe Hyrax::QuickClassificationQuery, singletenant: true do
   describe "tenant-specific work type filtering for work creation" do
     let(:user) { create(:user) }
-    
+
     before do
       # Ensure all work types are registered
       allow(Hyrax.config).to receive(:registered_curation_concern_types).and_return([
-        'GenericWork', 'Image', 'Etd', 'Oer', 'MobiusWork', 'UncaWork', 'ScholarlyWork'
-      ])
-      
+                                                                                      'GenericWork', 'Image', 'Etd', 'Oer', 'MobiusWork', 'UncaWork', 'ScholarlyWork'
+                                                                                    ])
+
       # Mock user permissions to allow creation of all work types
       allow(user).to receive(:can?).with(:create, anything).and_return(true)
     end
-    
+
     describe "tenant filtering" do
       context "for UNCA tenant" do
         before do
@@ -21,43 +21,43 @@ RSpec.describe Hyrax::QuickClassificationQuery, singletenant: true do
           account = double('Account', cname: 'unca.hykuup.com')
           allow(Account).to receive(:find_by).with(tenant: 'unca').and_return(account)
         end
-        
+
         it "excludes MobiusWork from work creation options" do
           query = described_class.new(user)
           authorized_models = query.authorized_models
-          
+
           expect(authorized_models.map(&:name)).to include('GenericWork', 'Image', 'Etd', 'Oer', 'ScholarlyWork', 'UncaWork')
           expect(authorized_models.map(&:name)).not_to include('MobiusWork')
         end
       end
-      
+
       context "for Mobius tenant" do
         before do
           allow(Apartment::Tenant).to receive(:current).and_return('mobius')
           account = double('Account', cname: 'example.digitalmobius.org')
           allow(Account).to receive(:find_by).with(tenant: 'mobius').and_return(account)
         end
-        
+
         it "excludes UncaWork and ScholarlyWork from work creation options" do
           query = described_class.new(user)
           authorized_models = query.authorized_models
-          
+
           expect(authorized_models.map(&:name)).to include('GenericWork', 'Image', 'Etd', 'Oer', 'MobiusWork')
           expect(authorized_models.map(&:name)).not_to include('UncaWork', 'ScholarlyWork')
         end
       end
-      
+
       context "for generic tenant" do
         before do
           allow(Apartment::Tenant).to receive(:current).and_return('generic')
           account = double('Account', cname: 'example.com')
           allow(Account).to receive(:find_by).with(tenant: 'generic').and_return(account)
         end
-        
+
         it "excludes all tenant-specific work types from work creation options" do
           query = described_class.new(user)
           authorized_models = query.authorized_models
-          
+
           expect(authorized_models.map(&:name)).to include('GenericWork', 'Image', 'Etd', 'Oer')
           expect(authorized_models.map(&:name)).not_to include('MobiusWork', 'UncaWork', 'ScholarlyWork')
         end


### PR DESCRIPTION
# Summary

This PR implements tenant-specific work type filtering to completely hide work types that shouldn't be visible to specific tenants, rather than just graying them out.

## Ticket Number
- https://github.com/notch8/hykuup_knapsack/issues/525

# Screenshots / Video
*Before*: All of the work types were available to all of the tenants.

*After*: Work types are completely hidden based on tenant-specific rules

## MOBIUS

<details><summary> default profile </summary> 

<img width="1352" height="798" alt="image" src="https://github.com/user-attachments/assets/05711081-8c18-401e-bdd9-d6d6084f7c81" />

<img width="1258" height="629" alt="image" src="https://github.com/user-attachments/assets/e0a85c75-4c5f-465c-a55c-762de75fc4c7" />

<img width="2704" height="1460" alt="image" src="https://github.com/user-attachments/assets/177d91cb-567b-40e0-be0c-3bf9ce6e8f50" />

</details>

<details><summary> When importing a profile without the custom work types </summary> 

<img width="1345" height="791" alt="image" src="https://github.com/user-attachments/assets/1d9cfaaf-a4fe-4c88-bc5d-70a894d5d0a3" />

<img width="2704" height="1460" alt="image" src="https://github.com/user-attachments/assets/9792d4c6-42bb-484f-b494-d2979925691f" />

</details>

## UNCA

<details><summary> default profile </summary> 

<img width="2704" height="1462" alt="image" src="https://github.com/user-attachments/assets/8c9aef4d-1725-4876-ab95-63caf73d2621" />

<img width="2704" height="1462" alt="image" src="https://github.com/user-attachments/assets/6ae500fa-17d9-4107-ac52-d2979925691f" />

<img width="2704" height="1460" alt="image" src="https://github.com/user-attachments/assets/c8c7f1bb-8621-441e-b709-89b9af771d72" />

</details>

<details><summary> When importing a profile without the custom work types </summary>

<img width="1348" height="754" alt="image" src="https://github.com/user-attachments/assets/89241812-3af8-4b47-b4cf-f3018dbc3be8" />

<img width="1348" height="793" alt="image" src="https://github.com/user-attachments/assets/67ecd9cc-155e-4ef3-bb0c-2531393f6410" />

</details> 

## DEV

<details><summary> default profile </summary> 

<img width="2704" height="1460" alt="image" src="https://github.com/user-attachments/assets/522d0ddc-9e4c-4bd2-b600-388b2f9d9eb6" />

<img width="2704" height="1460" alt="image" src="https://github.com/user-attachments/assets/7b49578f-2e87-4ff3-9cf5-b581720e35c0" />

</details> 



<details><summary>  When importing a profile with those custom work types </summary> 

<img width="1248" height="530" alt="image" src="https://github.com/user-attachments/assets/bb0fe5fd-8838-4e0e-bea6-f1b128124c35" />

</details>

<details><summary> When importing a profile with an invalid work type </summary>

<img width="1350" height="625" alt="image" src="https://github.com/user-attachments/assets/6964b1df-be8a-4d03-9dda-80e8b68f2adc" />

</details>

# Expected Behavior 

**Tenant-specific rules:**
- **UNCA tenant** (`unca.hykuup.com`): Should NOT see `MobiusWork`
- **Mobius tenant** (`*.digitalmobius.org`): Should NOT see `UncaWork` or `ScholarlyWork`  
- **All other tenants**: Should NOT see any tenant-specific work types (`MobiusWork`, `UncaWork`, `ScholarlyWork`)

**Key changes:**
1. **Dynamic Profile Loading**: Modified `Hyrax::FlexibleSchema.create_default_schema` to load tenant-specific metadata profiles
2. **Work Type Filtering**: Created controller decorator to completely hide "unowned" work types
3. **View Override**: Updated admin work types page to use tenant-filtered work types
4. **Work Creation Filtering**: Added decorator to filter work creation modal by tenant
5. **Profile Upload Validation**: Added validation to prevent uploading profiles with unowned work types
6. **Complete Hiding**: Work types are now completely hidden instead of just disabled/grayed out

# Notes

- **Complete Tenant Isolation**: Work types are filtered across all interfaces (admin page, work creation, profile uploads)
- **Dynamic Approach**: Uses exclusion-based logic that automatically adapts to new work types
- **Decorator Pattern**: Follows established patterns in the codebase
- **Test Coverage**: Includes comprehensive unit tests covering all tenant scenarios
- **Multi-tenant Safe**: Properly handles tenant detection using `Apartment::Tenant.current`
- **Future-Proof**: Automatically includes new work types unless explicitly excluded
- **Performance**: Minimal overhead - filtering happens once per request
- **Maintainable**: Easy to add new tenant-specific rules by updating the exclusion logic

**Impact:**
- Improves user experience by hiding irrelevant work types completely
- Maintains security by preventing cross-tenant work type visibility
- Preserves existing functionality for profile-based filtering
- Reduces confusion by eliminating grayed-out work types that tenants can't use
- Prevents unauthorized profile uploads containing forbidden work types