### PR TITLE
Make mobius work metadata fields render in views

### DIFF
--- a/app/views/hyrax/mobius_works/_attribute_rows.html.erb
+++ b/app/views/hyrax/mobius_works/_attribute_rows.html.erb
@@ -1,0 +1,9 @@
+<% view_options_for(presenter).each do |field, options| %>
+  <% value = presenter.public_send(field) %>
+  <% render_attribute = value.present? && (value.is_a?(Enumerable) ? value.any?(&:present?) : true) %>
+  <% if field == :admin_note %>
+    <%= presenter.attribute_to_html(:admin_note, options) if presenter.editor? && render_attribute %>
+  <% else %>
+    <%= presenter.attribute_to_html(conform_field(field, options), conform_options(field, options)) if render_attribute %>
+  <% end %>
+<% end %>

--- a/config/metadata/mobius_work.yaml
+++ b/config/metadata/mobius_work.yaml
@@ -32,6 +32,8 @@ attributes:
       primary: false
       multiple: true
     predicate: http://purl.org/dc/terms/rightsHolder
+    view:
+      html_dl: true
   relation:
     type: string
     multiple: true
@@ -42,6 +44,8 @@ attributes:
       primary: false
       multiple: true
     predicate: http://purl.org/dc/terms/relation
+    view:
+      html_dl: true
   coverage:
     type: string
     multiple: true
@@ -52,6 +56,8 @@ attributes:
       primary: false
       multiple: true
     predicate: http://purl.org/dc/terms/coverage
+    view:
+      html_dl: true
   file_format:
     type: string
     multiple: true
@@ -62,3 +68,5 @@ attributes:
       primary: false
       multiple: true
     predicate: http://purl.org/dc/terms/FileFormat
+    view:
+      html_dl: true


### PR DESCRIPTION
# Story

Update yaml file to include view html_dl: true
Add view partial to render attribute rows generically

Refs #572 

# Expected Behavior Before Changes

Only some metadata displayed on work's show page

# Expected Behavior After Changes

All metadata displays on work's show page

# Screenshots / Video

<details>
<summary>Sample Mobius Work</summary>

<img width="1428" height="2701" alt="screencapture-abc-hykuup-knapsack-localhost-direct-concern-mobius-works-36a63604-4c0a-464c-ae2b-583de8e3d35f-2025-12-01-18_12_20" src="https://github.com/user-attachments/assets/85403976-4bad-4d1a-bf2b-c29f03badd3e" />

</details>

# Notes

