### PR TITLE
Hyku 7 follow up 

### DIFF
--- a/spec/hyku_knapsack/application_spec.rb
+++ b/spec/hyku_knapsack/application_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe Hyku::Application do
   let(:rails_root) { Rails.root }


### PR DESCRIPTION
…elper

- spec_helper now loads hyrax-webapp/spec/spec_helper.rb which requires Rails to already be initialized. Any spec file that touches Rails must require rails_helper (which boots Rails first) rather than spec_helper.

