### PR TITLE
Add more memory request and raise the limit

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -267,10 +267,10 @@ redis:
   master:
     resources:
       limits:
-        memory: "896Mi"
+        memory: "2048Mi"
         cpu: "100m"
       requests:
-        memory: "896Mi"
+        memory: "1024Mi"
         cpu: "20m"
     persistence:
       enabled: true


### PR DESCRIPTION
redis was oom killed cycling 
gave it more memory request and limits
