### PR TITLE
Catalog translations

### DIFF
--- a/lib/hyku_knapsack.rb
+++ b/lib/hyku_knapsack.rb
@@ -2,8 +2,6 @@
 
 # This project uses flexible metadata (Hyku 7). Set before the engine is required
 # so initializers and Hyrax read the correct value.
-ENV['HYRAX_FLEXIBLE'] = 'true'
-
 # Disable include_metadata when flexible mode is enabled.
 ENV['HYRAX_DISABLE_INCLUDE_METADATA'] = 'true' if ENV.fetch('HYRAX_FLEXIBLE', 'true') == 'true'
 

--- a/spec/helpers/hyrax/blacklight_override_decorator_spec.rb
+++ b/spec/helpers/hyrax/blacklight_override_decorator_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Spec to verify that catalog display labels respect the current locale when
+# using flexible metadata. Without the fix, load_flexible_schema freezes labels
+# at boot-time (default :en) locale and custom_label: true short-circuits any
+# future i18n resolution.
+RSpec.describe Hyrax::BlacklightOverride, type: :helper do
+  include Hyrax::BlacklightOverride
+
+  let(:profile_path) { HykuKnapsack::Engine.root.join('config', 'metadata_profiles', 'default', 'm3_profile.yaml') }
+  let(:profile) { YAML.safe_load_file(profile_path) }
+
+  # Snapshot class-level blacklight_config label state before mutating it,
+  # so we can restore it after — load_flexible_schema mutates shared class state.
+  let(:original_labels) do
+    CatalogController.blacklight_config.index_fields.transform_values { |f| [f.label, f.custom_label] }
+  end
+
+  before do
+    original_labels # evaluate before mutation
+
+    Hyrax::FlexibleSchema.delete_all
+    Hyrax::FlexibleSchema.create!(profile:)
+
+    # Simulate the cold-cache condition caused by load_translations! -> backend.reload!
+    # by forcing load_flexible_schema to run while the locale is :en (boot default),
+    # which is what happens in production before before_action :set_locale fires.
+    I18n.with_locale(:en) do
+      CatalogController.load_flexible_schema
+    end
+  end
+
+  after do
+    original_labels.each do |name, (label, custom_label)|
+      field = CatalogController.blacklight_config.index_fields[name]
+      next unless field
+      field.label = label
+      field.custom_label = custom_label
+    end
+  end
+
+  # 'title_tesim' is present in every profile with multi-locale display_label entries.
+  let(:field_name) { 'title_tesim' }
+  let(:document) { instance_double(SolrDocument, to_h: {}) }
+
+  def index_fields(_document)
+    CatalogController.blacklight_config.index_fields
+  end
+
+  context "when locale is :en" do
+    it "returns the English label" do
+      I18n.with_locale(:en) do
+        expect(index_field_label(document, field_name)).to include("Title")
+      end
+    end
+  end
+
+  context "when locale is :es after schema was loaded in :en" do
+    it "returns the Spanish label" do
+      I18n.with_locale(:es) do
+        expect(index_field_label(document, field_name)).to include("Título")
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Story
Refs #609 
Adds a spec to verify display label translations are working in the catalog. This spec is expected
to fail until Hyrax changes are pulled in.

Also removes unnecessary setting HYRAX_FLEXIBLE. This is set in docker-compose so this is redundant.

# Expected Behavior Before Changes

Text on the catalog search results page may randomly show an incorrect language translation or the i18n lookup text to be translated from the m3 profile.

# Expected Behavior After Changes

Catalog search results text displays correctly for metadata & facet labels. 

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes