### PR TITLE
Add deploy to test zoned stateful resources

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,6 +10,7 @@ on:
         type: choice
         options:
           - friends
+          - friends-zone
           - staging
           - argo
           - production

--- a/ops/friends-zone-deploy.tmpl.yaml
+++ b/ops/friends-zone-deploy.tmpl.yaml
@@ -1,0 +1,306 @@
+# POC deployment - to tear down:
+#   kubectl delete namespace hykuup-knapsack-zone-friends --context r2-friends
+#   Drop the PostgreSQL database: hykuup-knapsack-zone-friends
+#   Remove DNS entries for hykuup-knapsack-zone-friends.notch8.cloud if added
+#   EFS-backed PVCs (branding, derivatives, uploads) will also persist after namespace deletion
+#     and will have to be deleted separately
+replicaCount: 2
+
+resources:
+  limits:
+    memory: "4Gi"
+    cpu: "1000m"
+  requests:
+    memory: "2Gi"
+    cpu: "100m"
+
+livenessProbe:
+  enabled: false
+readinessProbe:
+  enabled: false
+
+brandingVolume:
+  storageClass: efs-sc
+derivativesVolume:
+  storageClass: efs-sc
+uploadsVolume:
+  storageClass: efs-sc
+  size: 200Gi
+
+imagePullSecrets:
+ - name: github
+
+extraVolumeMounts: &volMounts
+  - name: uploads
+    mountPath: /app/samvera/hyrax-webapp/tmp/imports
+    subPath: imports
+  - name: uploads
+    mountPath: /app/samvera/hyrax-webapp/tmp/exports
+    subPath: exports
+  - name: uploads
+    mountPath: /app/samvera/hyrax-webapp/public/system
+    subPath: public-system
+  - name: uploads
+    mountPath: /app/samvera/hyrax-webapp/public/uploads
+    subPath: public-uploads
+  - name: uploads
+    mountPath: /app/samvera/hyrax-webapp/tmp/network_files
+    subPath: network-files
+  - name: uploads
+    mountPath: /app/samvera/hyrax-webapp/storage/files
+    subPath: storage-files
+  - name: uploads
+    mountPath: /app/samvera/hyrax-webapp/log/rack_attack
+    subPath: rack-attack
+
+ingress:
+  enabled: true
+  ingressClassName: "nginx-ingress"
+  hosts:
+    - host: "hykuup-knapsack-zone-friends.notch8.cloud"
+      paths:
+        - path: /
+    - host: "*.hykuup-knapsack-zone-friends.notch8.cloud"
+      paths:
+        - path: /
+  annotations: {
+    nginx.org/client-max-body-size: "0",
+    cert-manager.io/cluster-issuer: letsencrypt-production-dns
+  }
+  tls:
+    - hosts:
+        - "hykuup-knapsack-zone-friends.notch8.cloud"
+        - "*.hykuup-knapsack-zone-friends.notch8.cloud"
+      secretName: hykuup-knapsack-zone-friends-tls
+
+extraEnvVars: &envVars
+  - name: BUNDLE_LOCAL__HYKU_KNAPSACK
+    value: /app/samvera
+  - name: BUNDLE_DISABLE_LOCAL_BRANCH_CHECK
+    value: "true"
+  - name: CONFDIR
+    value: "/app/samvera/hyrax-webapp/solr/conf"
+  - name: CLIENT_ADMIN_USER_EMAIL
+    value: $CLIENT_ADMIN_USER_EMAIL
+  - name: CLIENT_ADMIN_USER_PASSWORD
+    value: $CLIENT_ADMIN_USER_PASSWORD
+  - name: DB_ADAPTER
+    value: postgresql
+  - name: DB_HOST
+    value: postgres-postgresql.postgres.svc.cluster.local
+  - name: DB_NAME
+    value: hykuup-knapsack-zone-friends
+  - name: DB_USER
+    value: postgres
+  - name: FCREPO_BASE_PATH
+    value: /hykuup-knapsack-zone-friends
+  - name: FCREPO_HOST
+    value: fcrepo.fcrepo.svc.cluster.local
+  - name: FCREPO_PORT
+    value: "8080"
+  - name: FCREPO_REST_PATH
+    value: rest
+  - name: GOOGLE_ANALYTICS_ID
+    value: $GOOGLE_ANALYTICS_ID
+  - name: GOOGLE_OAUTH_APP_NAME
+    value: hykuup-knapsack-zone-friends
+  - name: GOOGLE_OAUTH_APP_VERSION
+    value: '1.0'
+  - name: GOOGLE_OAUTH_PRIVATE_KEY_SECRET
+    value: $GOOGLE_OAUTH_PRIVATE_KEY_SECRET
+  - name: GOOGLE_OAUTH_PRIVATE_KEY_PATH
+    value: prod-cred.p12
+  - name: GOOGLE_OAUTH_PRIVATE_KEY_VALUE
+    value: $GOOGLE_OAUTH_PRIVATE_KEY_VALUE
+  - name: GOOGLE_OAUTH_CLIENT_EMAIL
+    value: hyku-demo@hykuup-knapsack-zone-friends.notch8.cloud
+  - name: INITIAL_ADMIN_EMAIL
+    value: admin@example.com
+  - name: INITIAL_ADMIN_PASSWORD
+    value: $INITIAL_ADMIN_PASSWORD
+  - name: IN_DOCKER
+    value: "true"
+  - name: LD_LIBRARY_PATH
+    value: /app/fits/tools/mediainfo/linux
+  - name: PASSENGER_APP_ENV
+    value: production
+  - name: RAILS_CACHE_STORE_URL
+    value: redis://:$REDIS_PASSWORD@hykuup-knapsack-zone-friends-redis-master:6379/0
+  - name: RAILS_ENV
+    value: production
+  - name: RAILS_LOG_TO_STDOUT
+    value: "true"
+  - name: RAILS_MAX_THREADS
+    value: "5"
+  - name: RAILS_SERVE_STATIC_FILES
+    value: "true"
+  - name: REDIS_HOST
+    value: hykuup-knapsack-zone-friends-redis-master
+  - name: REDIS_URL
+    value: redis://:$REDIS_PASSWORD@hykuup-knapsack-zone-friends-redis-master:6379/0
+  - name: HYRAX_ACTIVE_JOB_QUEUE
+    value: good_job
+  - name: HYRAX_ANALYTICS
+    value: "true"
+  - name: HYRAX_ANALYTICS_PROVIDER
+    value: "ga4"
+  - name: HYRAX_FITS_PATH
+    value: /app/fits/fits.sh
+  - name: HYRAX_FLEXIBLE
+    value: "true"
+  - name: HYRAX_VALKYRIE
+    value: "true"
+  - name: HYKU_ATTACK_RATE_THROTTLE_OFF
+    value: "true"
+  - name: HYKU_BULKRAX_ENABLED
+    value: "true"
+  - name: HYKU_BLOCK_VALKYRIE_REDIRECT
+    value: "false"
+  - name: HYKU_CONTACT_EMAIL
+    value: example@hykuup-knapsack-zone-friends.notch8.cloud
+  - name: HYKU_CONTACT_EMAIL_TO
+    value: example@hykuup-knapsack-zone-friends.notch8.cloud
+  - name: HYKU_FILE_ACL
+    value: "true"
+  - name: HYKU_ADMIN_HOST
+    value: hykuup-knapsack-zone-friends.notch8.cloud
+  - name: HYKU_ADMIN_ONLY_TENANT_CREATION
+    value: "false"
+  - name: HYKU_ALLOW_SIGNUP
+    value: "false"
+  - name: HYKU_DEFAULT_HOST
+    value: "%{tenant}.hykuup-knapsack-zone-friends.notch8.cloud"
+  - name: HYKU_MULTITENANT
+    value: "true"
+  - name: HYKU_ROOT_HOST
+    value: hykuup-knapsack-zone-friends.notch8.cloud
+  - name: HYKU_SHOW_BACKTRACE
+    value: "true"
+  - name: NEGATIVE_CAPTCHA_SECRET
+    value: $NEGATIVE_CAPTCHA_SECRET
+  - name: SMTP_ADDRESS
+    value: "maildev-smtp.maildev.svc.cluster.local"
+  - name: SMTP_DOMAIN
+    value: "maildev-smtp.maildev.svc.cluster.local"
+  - name: SMTP_ENABLED
+    value: "true"
+  - name: SMTP_PORT
+    value: "1025"
+  - name: SMTP_TYPE
+    value: "plain"
+  - name: SMTP_USER_NAME
+    value: "admin"
+  - name: SMTP_STARTTLS
+    value: "false"
+  - name: SMTP_PASSWORD
+    value: $SMTP_PASSWORD
+  - name: SOLR_ADMIN_USER
+    value: admin
+  - name: SOLR_ADMIN_PASSWORD
+    value: $SOLR_ADMIN_PASSWORD
+  - name: SOLR_COLLECTION_NAME
+    value: hykuup-knapsack-zone-friends
+  - name: SOLR_COLLECTION_REPLICAS
+    value: "3"
+  - name: SOLR_CONFIGSET_NAME
+    value: hykuup-knapsack-zone-friends
+  - name: SOLR_HOST
+    value: solr.solr-poc
+  - name: SOLR_PORT
+    value: "8983"
+  - name: SOLR_URL
+    value: http://admin:$SOLR_ADMIN_PASSWORD@solr.solr-poc:8983/solr/
+  - name: SENTRY_DSN
+    value: $SENTRY_DSN
+  - name: SENTRY_ENVIRONMENT
+    value: "hykuup-knapsack-zone-friends"
+  - name: TEST_USER_EMAIL
+    value: user@example.com
+  - name: TEST_USER_PASSWORD
+    value: $TEST_USER_PASSWORD
+  - name: VALKYRIE_ID_TYPE
+    value: string
+  - name: VALKYRIE_TRANSITION
+    value: "true"
+
+worker:
+  replicaCount: 1
+  resources:
+    limits:
+      memory: "4Gi"
+      cpu: "1000m"
+    requests:
+      memory: "2Gi"
+      cpu: "100m"
+  extraVolumeMounts: *volMounts
+  extraEnvVars: *envVars
+  podSecurityContext:
+    runAsUser: 1001
+    runAsGroup: 101
+    fsGroup: 101
+    fsGroupChangePolicy: "OnRootMismatch"
+podSecurityContext:
+  runAsUser: 1001
+  runAsGroup: 101
+  fsGroup: 101
+  fsGroupChangePolicy: "OnRootMismatch"
+
+embargoRelease:
+  enabled: false
+leaseRelease:
+  enabled: false
+
+fcrepo:
+  enabled: false
+postgresql:
+  enabled: false
+redis:
+  image:
+    repository: bitnamilegacy/redis
+    tag: 7.0.2-debian-11-r7
+  master:
+    resources:
+      limits:
+        memory: "512Mi"
+        cpu: "100m"
+      requests:
+        memory: "256Mi"
+        cpu: "20m"
+  enabled: true
+  architecture: standalone
+  auth:
+    password: $REDIS_PASSWORD
+solr:
+  enabled: false
+
+externalFcrepoHost: fcrepo.fcrepo.svc.cluster.local
+
+externalPostgresql:
+  host: postgres-postgresql.postgres.svc.cluster.local
+  username: postgres
+  password: $DB_PASSWORD
+
+externalSolrHost: solr.solr-poc.svc.cluster.local
+externalSolrUser: admin
+externalSolrCollection: "hykuup-knapsack-zone-friends"
+externalSolrPassword: $SOLR_ADMIN_PASSWORD
+
+fits:
+  enabled: true
+  resources:
+    limits:
+      memory: "2Gi"
+      cpu: "1000m"
+    requests:
+      memory: "1Gi"
+      cpu: "250m"
+  servicePort: 8080
+  subPath: /fits
+
+global:
+  hyraxName: hykuup-knapsack-zone-friends-hyrax
+
+nginx:
+  enabled: false
+  service:
+    port: 80


### PR DESCRIPTION
Starting with Solr on zone-separated nodegroups

Working on a new Solr deployment on r2-friends on 3 new nodegroups, 1 per availability, generally 1 node per nodegroup, unless they're rolling. In order to be high-availability, we need to have 3 `SOLR_COLLECTION_REPLICAS`, 1 per zone.