### PR TITLE
Update submodule to e6704a4b

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "hyrax-webapp"]
 	path = hyrax-webapp
 	url = https://github.com/samvera/hyku.git
-	branch = 7.1-stable
+	branch = main

--- a/app/indexers/hyrax/indexers/file_set_indexer_decorator.rb
+++ b/app/indexers/hyrax/indexers/file_set_indexer_decorator.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# TEMPORARY OVERRIDE -- DELETE THIS FILE once the hyrax-webapp submodule is
+# bumped to a Hyrax revision that includes samvera/hyrax#7459 (adds the
+# `if resource.respond_to?(:transcript_ids)` guard upstream).
+#
+# Without that guard, FileSet indexing crashes for flexible-metadata tenants
+# whose M3 profile does not declare a `transcript_ids` property. Every
+# bulkrax file-set import hits NoMethodError at
+# `hyrax/indexers/file_set_indexer.rb:27` inside `to_solr`.
+#
+# We can't simply `super.tap` and patch the offending line because `super`
+# raises before returning. Instead, define `transcript_ids` as a singleton
+# method on the resource for this indexing call (only when the resource
+# doesn't already respond to it). Upstream then runs unchanged: it calls
+# `resource.transcript_ids` and gets nil, so `nil&.map(&:to_s)` is nil and
+# `solr_doc['transcript_ids_ssim']` is set to nil. No re-implementation.
+module Hyrax
+  module Indexers
+    module FileSetIndexerDecorator
+      def to_solr
+        resource.define_singleton_method(:transcript_ids) { nil } unless resource.respond_to?(:transcript_ids)
+        super
+      end
+    end
+  end
+end
+
+Hyrax::Indexers::FileSetIndexer.prepend(Hyrax::Indexers::FileSetIndexerDecorator)


### PR DESCRIPTION
Pulls in fix MeSH authority fix
Issue:
- https://github.com/notch8/hykuup_knapsack/issues/685
PR
- https://github.com/samvera/hyku/pull/3063

## Summary
- Fixes [notch8/hykuup_knapsack#685](https://github.com/notch8/hykuup_knapsack/issues/685): short exact MeSH descriptors like `RNA` were unreachable via autocomplete because substring matches (`mRNA`, `tRNA`, etc.) filled all 20 alphabetical slots before the exact term could appear.
- Replaces the plain `ILIKE` + alphabetical query in `app/authorities/qa/authorities/mesh.rb` with a SQL `CASE`-tiered `ORDER BY` so ranking happens **before** `LIMIT`:
  - Tier 0: exact (case-insensitive) match
  - Tier 1: prefix match
  - Tier 2: substring match
  - Alphabetical within each tier
- Adds `spec/authorities/qa/authorities/mesh_spec.rb` (8 examples) covering exact-first ranking, tier ordering, case-insensitivity, alphabetical-within-tier, the 20-row display cap, and the id-falls-back-to-label response shape.
- Drive-by fix: the original `.limit(20).order(:label)` chained the clauses such that the alphabetical sort ran *after* the limit in the generated SQL, making the ranking effectively arbitrary. The new query orders then limits.

## Acceptance criteria
- [x] Searching `RNA` returns `RNA` as the first result, not buried behind substring matches
- [x] Exact match (case-insensitive) ranks before prefix matches, which rank before substring matches
- [x] Alphabetical ordering is preserved within each tier
- [x] Display cap stays at 20 (constant, not tenant-configurable)

## Notes on scope
The original spike proposed reusing `Account#solr_max_results` / `solr_rows_per_request` to size a "ranking pool" and chunking with `in_batches`. Once SQL does the ranking, there is no Ruby-side pool to size, and `in_batches` re-orders by primary key which would silently break the `CASE` ordering. Implementation is simpler as a result and still meets all acceptance criteria.

Backlog follow-ups from the issue (out of scope here): synonym search against `qa_subject_mesh_terms.synonyms`, switching to the `term_lower` index, and an exact-match-only `=` convention.

## Test plan
- [x] `bundle exec rspec spec/authorities/qa/authorities/mesh_spec.rb` - 8 examples, 0 failures
- [x] `bundle exec rubocop` on changed files - no offenses
- [x] Manual check against a live tenant (St. Jude dev): `/authorities/search/mesh?q=RNA` returns `RNA` as the first result; `?q=heart` returns `Heart` first then prefix matches alphabetically; `?q=cancer` puts prefix-tier `Cancer-...` entries above substring-tier `American Cancer Society`
- [ ] Reviewer: confirm selecting a result from the dropdown still saves correctly to a work (form-side smoke test)

# BEFORE

<img width="922" height="590" alt="image" src="https://github.com/user-attachments/assets/2613ffb4-b522-4d2b-991a-92d3cc649670" />

# AFTER

<img width="409" height="233" alt="image" src="https://github.com/user-attachments/assets/e2b60bcd-3b3b-4987-af6a-24a6c6ca37f7" />
