### PR TITLE
i1353-proxy-connect-timeout

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -58,6 +58,7 @@ ingress:
         - path: /
   annotations: {
     nginx.org/client-max-body-size: "0",
+    nginx.org/proxy-connect-timeout: "120s",
     cert-manager.io/cluster-issuer: letsencrypt-production-dns
   }
   tls:


### PR DESCRIPTION
ref ticket: https://github.com/notch8/dev-ops/issues/1353

> persists what was altered live on production

Increase nginx proxy-connect-timeout to 120s on production ingress from default of 60s