### PR TITLE
Add hykuup:tenants:usage rake task for per-tenant usage reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,42 @@ rake hykuup:profiles:reset_all                             # All tenants
 rake hykuup:profiles:reset_tenant[demo]                    # Specific tenant
 ```
 
+## Tenant Usage Reporting
+
+Report object (work) counts and primary-file storage per tenant, optionally scoped to a consortium.
+
+```bash
+rake hykuup:tenants:usage[mobius]     # All tenants in the Mobius consortium
+rake hykuup:tenants:usage             # All (non-search-only) tenants
+```
+
+The consortium argument is optional and, when given, must be a valid identifier from
+`config/consortia.yml` (run without it to report every tenant). Tenants are selected by
+`part_of_consortia`, the same way as `hykuup:profiles:add_consortium_profiles`.
+
+**Output formats:**
+```bash
+rake hykuup:tenants:usage[mobius]                 # Padded table, sorted by storage, with totals
+format=csv rake hykuup:tenants:usage[mobius]      # CSV (tenant,works,files,bytes,storage_human)
+
+# Save CSV to a file you can copy out of the pod:
+format=csv rake hykuup:tenants:usage[mobius] | tee /tmp/mobius_usage.csv
+```
+
+Progress is written to stderr (one line per tenant) so stdout stays clean for piping.
+
+**What it measures:**
+- **Works** counts curation-concern objects (`Hyrax.config.curation_concerns`).
+- **Files** / **Storage** sum `file_size_lts` (bytes) across the tenant's FileSets. This is
+  the ORIGINAL/primary file size only. It excludes derivatives, thumbnails, and prior file
+  versions, and reflects only what has been characterized and indexed, so real disk/object-store
+  usage will be somewhat higher.
+
+> Note: this task supersedes Hyku's `tenants:calculate_usage`, which reports `0 MB` on
+> Valkyrie/flexible-metadata indexes (it reads the empty `file_set_ids_ssim` field and cannot
+> sum the stored-but-not-indexed `file_size_lts`). This task pages the FileSet docs and sums
+> in Ruby instead.
+
 ## Adding New Consortia
 
 <details>

--- a/bin/mobius_usage.rb
+++ b/bin/mobius_usage.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+#
+# Report object count + storage usage per MOBIUS tenant.
+#
+# Usage (from the Hyku app dir, e.g. /app/samvera/hyrax-webapp in the pod):
+#
+#   bundle exec rails runner bin/mobius_usage.rb
+#
+# Options (environment variables):
+#   tenants="a.digitalmobius.org b.digitalmobius.org"  # override auto-detection with an explicit list
+#   format=csv                                         # emit CSV instead of a padded table
+#   all=true                                           # report ALL non-search-only tenants, not just mobius
+#
+# Notes:
+# - Storage is the sum of `file_size_lts` (bytes) across every FileSet in the tenant.
+#   That field is stored-but-not-indexed in Solr, so we page through the FileSet docs
+#   and sum in Ruby (stats/range queries return nothing on it). This is the
+#   ORIGINAL/primary file size only; it does NOT include derivatives, thumbnails, or
+#   prior file versions, and only reflects what has been characterized + indexed.
+# - "Works" counts curation-concern objects; "Files" counts FileSets that carry a size.
+
+def human_size(bytes)
+  units = %w[B KB MB GB TB PB]
+  size = bytes.to_f
+  unit = 0
+  while size >= 1024 && unit < units.length - 1
+    size /= 1024
+    unit += 1
+  end
+  format('%.2f %s', size, units[unit])
+end
+
+def mobius_accounts
+  Account.where(part_of_consortia: 'mobius')
+         .or(Account.where('cname LIKE ?', '%mobius%'))
+         .or(Account.where(cname: 'stephens.hykuup.com'))
+end
+
+def selected_accounts
+  explicit = ENV.fetch('tenants', '').split
+  return Account.where(cname: explicit) if explicit.any?
+  return Account.where(search_only: false) if ENV['all'] == 'true'
+
+  mobius_accounts.where(search_only: false)
+end
+
+# Fetch one page of FileSet docs (id + file_size_lts only) via cursorMark.
+def file_set_page(cursor)
+  ActiveFedora::SolrService.get(
+    'has_model_ssim:FileSet OR has_model_ssim:"Hyrax::FileSet"',
+    rows: 1000,
+    fl: 'file_size_lts',
+    sort: 'id asc',
+    cursorMark: cursor
+  )
+end
+
+# Sum file_size_lts (bytes) and count docs that carry a size for a page of docs.
+def sum_page(docs)
+  bytes = 0
+  files = 0
+  docs.each do |doc|
+    size = doc['file_size_lts']
+    size = size.first if size.is_a?(Array)
+    next if size.nil?
+
+    bytes += size.to_i
+    files += 1
+  end
+  [bytes, files]
+end
+
+# Sum primary-file storage (bytes) and file count for the CURRENT tenant.
+# file_size_lts is stored-but-NOT-indexed in the Samvera Solr schema, so it can't be
+# range-queried or summed via the stats component. Page the FileSet docs with
+# cursorMark (no deep-paging cost) and sum in Ruby.
+def tenant_file_storage
+  total_bytes = 0
+  total_files = 0
+  cursor = '*'
+  loop do
+    resp = file_set_page(cursor)
+    docs = resp.dig('response', 'docs') || []
+    bytes, files = sum_page(docs)
+    total_bytes += bytes
+    total_files += files
+    next_cursor = resp['nextCursorMark']
+    break if docs.empty? || next_cursor.nil? || next_cursor == cursor
+
+    cursor = next_cursor
+  end
+  [total_bytes, total_files]
+end
+
+work_models = Hyrax.config.curation_concerns.map { |m| %("#{m}") }.join(' OR ')
+rows = []
+
+selected_accounts.find_each do |account|
+  next if account.cname.blank?
+
+  AccountElevator.switch!(account.cname)
+
+  works = ActiveFedora::SolrService.count("has_model_ssim:(#{work_models})")
+  bytes, files = tenant_file_storage
+
+  rows << { cname: account.cname, works:, files:, bytes: }
+  warn "processed #{account.cname} (#{works} works, #{human_size(bytes)})"
+end
+
+rows.sort_by! { |r| -r[:bytes] }
+
+total_works = rows.sum { |r| r[:works] }
+total_files = rows.sum { |r| r[:files] }
+total_bytes = rows.sum { |r| r[:bytes] }
+
+if ENV['format'] == 'csv'
+  puts 'tenant,works,files,bytes,storage_human'
+  rows.each { |r| puts "#{r[:cname]},#{r[:works]},#{r[:files]},#{r[:bytes]},#{human_size(r[:bytes])}" }
+  puts "TOTAL,#{total_works},#{total_files},#{total_bytes},#{human_size(total_bytes)}"
+else
+  w = ([30] + rows.map { |r| r[:cname].length }).max
+  # Format strings are held in variables so the dynamic width (#{w}) does not confuse
+  # RuboCop's Lint/FormatParameterMismatch, which only analyzes literal format strings.
+  head_fmt = "%-#{w}s  %8s  %8s  %14s"
+  row_fmt = "%-#{w}s  %8d  %8d  %14s"
+  puts format(head_fmt, 'TENANT', 'WORKS', 'FILES', 'STORAGE')
+  puts '-' * (w + 38)
+  rows.each do |r|
+    puts format(row_fmt, r[:cname], r[:works], r[:files], human_size(r[:bytes]))
+  end
+  puts '-' * (w + 38)
+  puts format(row_fmt, "TOTAL (#{rows.size} tenants)", total_works, total_files, human_size(total_bytes))
+end

--- a/lib/tasks/hyku_knapsack_tasks.rake
+++ b/lib/tasks/hyku_knapsack_tasks.rake
@@ -10,6 +10,50 @@ def fmt
   HykuKnapsack::CLIFormatter
 end
 
+# Human-readable byte size, e.g. 58.30 GB
+def human_size(bytes)
+  units = %w[B KB MB GB TB PB]
+  size = bytes.to_f
+  unit = 0
+  while size >= 1024 && unit < units.length - 1
+    size /= 1024
+    unit += 1
+  end
+  format('%.2f %s', size, units[unit])
+end
+
+# Sum primary-file storage (bytes) and file count for the CURRENT tenant.
+# file_size_lts is stored-but-not-indexed in Solr, so it can't be summed via stats;
+# we page the FileSet docs (id + file_size_lts only) with cursorMark and sum in Ruby.
+def tenant_file_storage
+  bytes = 0
+  files = 0
+  cursor = '*'
+  loop do
+    resp = ActiveFedora::SolrService.get(
+      'has_model_ssim:FileSet OR has_model_ssim:"Hyrax::FileSet"',
+      rows: 1000,
+      fl: 'file_size_lts',
+      sort: 'id asc',
+      cursorMark: cursor
+    )
+    docs = resp.dig('response', 'docs') || []
+    docs.each do |doc|
+      size = doc['file_size_lts']
+      size = size.first if size.is_a?(Array)
+      next if size.nil?
+
+      bytes += size.to_i
+      files += 1
+    end
+    next_cursor = resp['nextCursorMark']
+    break if docs.empty? || next_cursor.nil? || next_cursor == cursor
+
+    cursor = next_cursor
+  end
+  [bytes, files]
+end
+
 namespace :hykuup do
   namespace :mobius do
     desc 'Update Bulkrax field mappings across all Mobius tenants'
@@ -81,6 +125,63 @@ namespace :hykuup do
 
         account.bulkrax_field_mappings = field_mappings.to_json
         account.save!
+      end
+    end
+  end
+
+  namespace :tenants do
+    desc 'Report object count + primary-file storage per tenant. ' \
+         'Pass a consortium to scope to that group, omit for all tenants. ' \
+         'Usage: rake hykuup:tenants:usage[mobius]  (set format=csv for CSV output)'
+    task :usage, [:consortium] => :environment do |_t, args|
+      consortium = args[:consortium]
+
+      accounts =
+        if consortium.present?
+          unless Consortium.identifiers.include?(consortium)
+            puts fmt.red("\nError: Invalid consortium '#{consortium}'")
+            puts "Available consortia: #{Consortium.identifiers.join(', ')}"
+            exit 1
+          end
+          Account.where(part_of_consortia: consortium, search_only: false)
+        else
+          Account.where(search_only: false)
+        end
+
+      work_models = Hyrax.config.curation_concerns.map { |m| %("#{m}") }.join(' OR ')
+      rows = []
+
+      accounts.find_each do |account|
+        next if account.cname.blank?
+
+        AccountElevator.switch!(account.cname)
+        works = ActiveFedora::SolrService.count("has_model_ssim:(#{work_models})")
+        bytes, files = tenant_file_storage
+
+        rows << { cname: account.cname, works: works, files: files, bytes: bytes }
+        warn "processed #{account.cname} (#{works} works, #{human_size(bytes)})"
+      end
+
+      rows.sort_by! { |r| -r[:bytes] }
+      total_works = rows.sum { |r| r[:works] }
+      total_files = rows.sum { |r| r[:files] }
+      total_bytes = rows.sum { |r| r[:bytes] }
+
+      if ENV['format'] == 'csv'
+        puts 'tenant,works,files,bytes,storage_human'
+        rows.each { |r| puts "#{r[:cname]},#{r[:works]},#{r[:files]},#{r[:bytes]},#{human_size(r[:bytes])}" }
+        puts "TOTAL,#{total_works},#{total_files},#{total_bytes},#{human_size(total_bytes)}"
+      else
+        scope = consortium.present? ? "#{consortium.upcase} CONSORTIUM" : 'ALL TENANTS'
+        puts fmt.header("USAGE REPORT: #{scope}", "📊")
+        w = ([30] + rows.map { |r| r[:cname].length }).max
+        puts format("%-#{w}s  %8s  %8s  %14s", 'TENANT', 'WORKS', 'FILES', 'STORAGE')
+        puts fmt.thin_separator
+        rows.each do |r|
+          puts format("%-#{w}s  %8d  %8d  %14s", r[:cname], r[:works], r[:files], human_size(r[:bytes]))
+        end
+        puts fmt.thin_separator
+        puts format("%-#{w}s  %8d  %8d  %14s", "TOTAL (#{rows.size} tenants)", total_works, total_files, human_size(total_bytes))
       end
     end
   end

--- a/lib/tasks/hyku_knapsack_tasks.rake
+++ b/lib/tasks/hyku_knapsack_tasks.rake
@@ -22,36 +22,51 @@ def human_size(bytes)
   format('%.2f %s', size, units[unit])
 end
 
+# Fetch one page of FileSet docs (id + file_size_lts only) via cursorMark.
+def file_set_page(cursor)
+  ActiveFedora::SolrService.get(
+    'has_model_ssim:FileSet OR has_model_ssim:"Hyrax::FileSet"',
+    rows: 1000,
+    fl: 'file_size_lts',
+    sort: 'id asc',
+    cursorMark: cursor
+  )
+end
+
+# Sum file_size_lts (bytes) and count docs that carry a size for a page of docs.
+def sum_page(docs)
+  bytes = 0
+  files = 0
+  docs.each do |doc|
+    size = doc['file_size_lts']
+    size = size.first if size.is_a?(Array)
+    next if size.nil?
+
+    bytes += size.to_i
+    files += 1
+  end
+  [bytes, files]
+end
+
 # Sum primary-file storage (bytes) and file count for the CURRENT tenant.
 # file_size_lts is stored-but-not-indexed in Solr, so it can't be summed via stats;
 # we page the FileSet docs (id + file_size_lts only) with cursorMark and sum in Ruby.
 def tenant_file_storage
-  bytes = 0
-  files = 0
+  total_bytes = 0
+  total_files = 0
   cursor = '*'
   loop do
-    resp = ActiveFedora::SolrService.get(
-      'has_model_ssim:FileSet OR has_model_ssim:"Hyrax::FileSet"',
-      rows: 1000,
-      fl: 'file_size_lts',
-      sort: 'id asc',
-      cursorMark: cursor
-    )
+    resp = file_set_page(cursor)
     docs = resp.dig('response', 'docs') || []
-    docs.each do |doc|
-      size = doc['file_size_lts']
-      size = size.first if size.is_a?(Array)
-      next if size.nil?
-
-      bytes += size.to_i
-      files += 1
-    end
+    bytes, files = sum_page(docs)
+    total_bytes += bytes
+    total_files += files
     next_cursor = resp['nextCursorMark']
     break if docs.empty? || next_cursor.nil? || next_cursor == cursor
 
     cursor = next_cursor
   end
-  [bytes, files]
+  [total_bytes, total_files]
 end
 
 namespace :hykuup do
@@ -158,7 +173,7 @@ namespace :hykuup do
         works = ActiveFedora::SolrService.count("has_model_ssim:(#{work_models})")
         bytes, files = tenant_file_storage
 
-        rows << { cname: account.cname, works: works, files: files, bytes: bytes }
+        rows << { cname: account.cname, works:, files:, bytes: }
         warn "processed #{account.cname} (#{works} works, #{human_size(bytes)})"
       end
 
@@ -175,13 +190,17 @@ namespace :hykuup do
         scope = consortium.present? ? "#{consortium.upcase} CONSORTIUM" : 'ALL TENANTS'
         puts fmt.header("USAGE REPORT: #{scope}", "📊")
         w = ([30] + rows.map { |r| r[:cname].length }).max
-        puts format("%-#{w}s  %8s  %8s  %14s", 'TENANT', 'WORKS', 'FILES', 'STORAGE')
+        # Format strings are held in variables so the dynamic width (#{w}) does not confuse
+        # RuboCop's Lint/FormatParameterMismatch, which only analyzes literal format strings.
+        head_fmt = "%-#{w}s  %8s  %8s  %14s"
+        row_fmt = "%-#{w}s  %8d  %8d  %14s"
+        puts format(head_fmt, 'TENANT', 'WORKS', 'FILES', 'STORAGE')
         puts fmt.thin_separator
         rows.each do |r|
-          puts format("%-#{w}s  %8d  %8d  %14s", r[:cname], r[:works], r[:files], human_size(r[:bytes]))
+          puts format(row_fmt, r[:cname], r[:works], r[:files], human_size(r[:bytes]))
         end
         puts fmt.thin_separator
-        puts format("%-#{w}s  %8d  %8d  %14s", "TOTAL (#{rows.size} tenants)", total_works, total_files, human_size(total_bytes))
+        puts format(row_fmt, "TOTAL (#{rows.size} tenants)", total_works, total_files, human_size(total_bytes))
       end
     end
   end

--- a/lib/tasks/hyku_knapsack_tasks.rake
+++ b/lib/tasks/hyku_knapsack_tasks.rake
@@ -27,7 +27,7 @@ def file_set_page(cursor)
   ActiveFedora::SolrService.get(
     'has_model_ssim:FileSet OR has_model_ssim:"Hyrax::FileSet"',
     rows: 1000,
-    fl: 'file_size_lts',
+    fl: 'id,file_size_lts',
     sort: 'id asc',
     cursorMark: cursor
   )


### PR DESCRIPTION
Reports work counts and primary-file storage per tenant, optionally scoped to a consortium. Pages FileSet docs and sums file_size_lts in Ruby, since that field is stored-but-not-indexed in Solr and cannot be summed via stats (which is why Hyku's tenants:calculate_usage reports 0 on Valkyrie/flexible-metadata indexes).

```
TENANT                             WORKS     FILES         STORAGE
--------------------------------------------------------------------
truman.digitalmobius.org            4601     16087        58.30 GB
webster.digitalmobius.org            293       396        28.35 GB
nwmsu.digitalmobius.org              386       390        27.42 GB
jewell.digitalmobius.org             662       584         9.78 GB
mbts.digitalmobius.org              1842      1919         6.92 GB
moval.digitalmobius.org              145       147         4.87 GB
mssu.digitalmobius.org              4247      4247         3.22 GB
stlcc.digitalmobius.org              136       145         2.74 GB
covenant.digitalmobius.org           359       392         1.82 GB
crowder.digitalmobius.org            353       353         1.72 GB
stephens.digitalmobius.org            76        82         1.69 GB
ccis.digitalmobius.org              1043      1082         1.20 GB
sbuniv.digitalmobius.org             420       422       815.24 MB
mobap.digitalmobius.org               58        58        55.12 MB
atsu.digitalmobius.org                 3         5        53.77 MB
kenrick.digitalmobius.org              7         5         8.30 MB
eastcentral.digitalmobius.org          0         0          0.00 B
--------------------------------------------------------------------
TOTAL (17 tenants)                 14631     26314       148.93 GB
```