### PR TITLE
Add monitoring for Puma

### DIFF
--- a/lib/hyku_knapsack/engine.rb
+++ b/lib/hyku_knapsack/engine.rb
@@ -1,8 +1,18 @@
 # frozen_string_literal: true
 
+require 'hyku_knapsack/monitoring_middleware'
+
 module HykuKnapsack
   class Engine < ::Rails::Engine
     isolate_namespace HykuKnapsack
+
+    # Serve monitoring endpoints (/monitoring/puma_stats, /monitoring/deps) for
+    # external uptime checks. Inserted at position 0 so they stay up (and cheap)
+    # even when the database or Redis is not: they bypass Rack::Attack,
+    # sessions, and tenant middleware.
+    initializer 'hyku_knapsack.monitoring_middleware' do |app|
+      app.middleware.insert_before 0, HykuKnapsack::MonitoringMiddleware
+    end
 
     # Load knapsack initializers from config/initializers/ AFTER the host app's
     # initializers run (e.g. after hyku's 1flexible.rb), so knapsack overrides win.

--- a/lib/hyku_knapsack/monitoring_middleware.rb
+++ b/lib/hyku_knapsack/monitoring_middleware.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'rack/utils'
+
+module HykuKnapsack
+  # Rack middleware that exposes Puma's runtime stats as JSON for external
+  # monitoring (Site24x7 polls this to alert on thread-pool exhaustion before
+  # it becomes user-facing downtime).
+  #
+  # Inserted at the very front of the middleware stack (see engine.rb) so the
+  # response never touches the database, Redis, or tenant resolution — if Puma
+  # can serve anything at all, it can serve this.
+  #
+  # GET /monitoring/puma_stats
+  #   In single-mode Puma (how this app runs, see bin/web) the payload looks
+  #   like:
+  #     { "started_at": "...", "backlog": 0, "running": 7, "pool_capacity": 5,
+  #       "max_threads": 7, "requests_count": 12345 }
+  #   pool_capacity is the number of additional requests this process could
+  #   accept right now (0 = saturated); backlog is requests accepted but not
+  #   yet assigned a thread.
+  #
+  # Access is open by default. Set MONITORING_TOKEN to require
+  # `Authorization: Bearer <token>` (or a `?token=` query param, which some
+  # monitoring products are easier to configure with).
+  class MonitoringMiddleware
+    PUMA_STATS_PATH = '/monitoring/puma_stats'
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      return @app.call(env) unless env['PATH_INFO'] == PUMA_STATS_PATH
+      return respond(405, 'error' => 'method not allowed') unless env['REQUEST_METHOD'] == 'GET'
+      return respond(401, 'error' => 'unauthorized') unless authorized?(env)
+
+      stats = puma_stats
+      return respond(503, 'error' => 'puma stats unavailable') unless stats
+
+      respond(200, stats)
+    end
+
+    private
+
+    def respond(status, body)
+      json = JSON.generate(body)
+      [status, { 'Content-Type' => 'application/json', 'Content-Length' => json.bytesize.to_s }, [json]]
+    end
+
+    def authorized?(env)
+      expected = ENV['MONITORING_TOKEN']
+      return true if expected.nil? || expected.empty?
+
+      provided = bearer_token(env) || Rack::Utils.parse_query(env['QUERY_STRING'].to_s)['token']
+      return false unless provided.is_a?(String) && provided.bytesize == expected.bytesize
+
+      Rack::Utils.secure_compare(expected, provided)
+    end
+
+    def bearer_token(env)
+      header = env['HTTP_AUTHORIZATION'].to_s
+      header.start_with?('Bearer ') ? header.delete_prefix('Bearer ') : nil
+    end
+
+    # Puma.stats_hash is only usable once the Puma launcher has registered its
+    # stats object (i.e. the app is actually being served by Puma). Under other
+    # entry points (rake, console) it raises NoMethodError on the nil stats
+    # object, which we translate into a 503.
+    def puma_stats
+      return nil unless defined?(Puma) && Puma.respond_to?(:stats_hash)
+
+      Puma.stats_hash
+    rescue NoMethodError
+      nil
+    end
+  end
+end

--- a/lib/hyku_knapsack/monitoring_middleware.rb
+++ b/lib/hyku_knapsack/monitoring_middleware.rb
@@ -51,7 +51,7 @@ module HykuKnapsack
 
     def authorized?(env)
       expected = ENV['MONITORING_TOKEN']
-      return true if expected.nil? || expected.empty?
+      return true if expected.blank?
 
       provided = bearer_token(env) || Rack::Utils.parse_query(env['QUERY_STRING'].to_s)['token']
       return false unless provided.is_a?(String) && provided.bytesize == expected.bytesize

--- a/spec/hyku_knapsack/monitoring_middleware_spec.rb
+++ b/spec/hyku_knapsack/monitoring_middleware_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe HykuKnapsack::MonitoringMiddleware do
   end
 
   def request(path: described_class::PUMA_STATS_PATH, method: 'GET', query: '', headers: {})
-    env = Rack::MockRequest.env_for("#{path}#{query.empty? ? '' : "?#{query}"}", method: method)
+    env = Rack::MockRequest.env_for("#{path}#{query.empty? ? '' : "?#{query}"}", method:)
     headers.each { |key, value| env[key] = value }
     middleware.call(env)
   end
@@ -45,7 +45,7 @@ RSpec.describe HykuKnapsack::MonitoringMiddleware do
 
     context 'with a non-GET request' do
       it 'returns 405' do
-        status, _, = response = request(method: 'POST')
+        status, = response = request(method: 'POST')
         expect(status).to eq(405)
         expect(body_json(response)).to eq('error' => 'method not allowed')
       end
@@ -68,7 +68,7 @@ RSpec.describe HykuKnapsack::MonitoringMiddleware do
     context 'when Puma stats are unavailable' do
       it 'returns 503 when the stats object is not registered' do
         allow(Puma).to receive(:stats_hash).and_raise(NoMethodError)
-        status, _, = response = request
+        status, = response = request
         expect(status).to eq(503)
         expect(body_json(response)).to eq('error' => 'puma stats unavailable')
       end
@@ -84,7 +84,7 @@ RSpec.describe HykuKnapsack::MonitoringMiddleware do
       before { stub_env('MONITORING_TOKEN' => 'sekret') }
 
       it 'returns 401 without a token' do
-        status, _, = response = request
+        status, = response = request
         expect(status).to eq(401)
         expect(body_json(response)).to eq('error' => 'unauthorized')
       end

--- a/spec/hyku_knapsack/monitoring_middleware_spec.rb
+++ b/spec/hyku_knapsack/monitoring_middleware_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HykuKnapsack::MonitoringMiddleware do
+  let(:downstream_response) { [200, { 'Content-Type' => 'text/plain' }, ['downstream']] }
+  let(:app) { ->(_env) { downstream_response } }
+  let(:middleware) { described_class.new(app) }
+  let(:puma_stats) do
+    {
+      'started_at' => '2026-07-10T00:00:00Z',
+      'backlog' => 0,
+      'running' => 7,
+      'pool_capacity' => 5,
+      'max_threads' => 7,
+      'requests_count' => 12_345
+    }
+  end
+
+  def request(path: described_class::PUMA_STATS_PATH, method: 'GET', query: '', headers: {})
+    env = Rack::MockRequest.env_for("#{path}#{query.empty? ? '' : "?#{query}"}", method: method)
+    headers.each { |key, value| env[key] = value }
+    middleware.call(env)
+  end
+
+  def body_json(response)
+    JSON.parse(response.last.join)
+  end
+
+  def stub_env(vars)
+    allow(ENV).to receive(:[]).and_call_original
+    vars.each { |name, value| allow(ENV).to receive(:[]).with(name).and_return(value) }
+  end
+
+  before do
+    allow(Puma).to receive(:stats_hash).and_return(puma_stats)
+  end
+
+  describe '#call' do
+    context 'when the path is not the monitoring endpoint' do
+      it 'passes the request through to the app' do
+        expect(request(path: '/catalog')).to eq(downstream_response)
+      end
+    end
+
+    context 'with a non-GET request' do
+      it 'returns 405' do
+        status, _, = response = request(method: 'POST')
+        expect(status).to eq(405)
+        expect(body_json(response)).to eq('error' => 'method not allowed')
+      end
+    end
+
+    context 'when Puma is serving' do
+      it 'returns the stats as JSON' do
+        status, headers, = response = request
+        expect(status).to eq(200)
+        expect(headers['Content-Type']).to eq('application/json')
+        expect(body_json(response)).to eq(puma_stats)
+      end
+
+      it 'sets Content-Length to the body size' do
+        _, headers, body = request
+        expect(headers['Content-Length']).to eq(body.join.bytesize.to_s)
+      end
+    end
+
+    context 'when Puma stats are unavailable' do
+      it 'returns 503 when the stats object is not registered' do
+        allow(Puma).to receive(:stats_hash).and_raise(NoMethodError)
+        status, _, = response = request
+        expect(status).to eq(503)
+        expect(body_json(response)).to eq('error' => 'puma stats unavailable')
+      end
+
+      it 'returns 503 when Puma does not respond to stats_hash' do
+        allow(Puma).to receive(:respond_to?).and_call_original
+        allow(Puma).to receive(:respond_to?).with(:stats_hash).and_return(false)
+        expect(request.first).to eq(503)
+      end
+    end
+
+    context 'when MONITORING_TOKEN is set' do
+      before { stub_env('MONITORING_TOKEN' => 'sekret') }
+
+      it 'returns 401 without a token' do
+        status, _, = response = request
+        expect(status).to eq(401)
+        expect(body_json(response)).to eq('error' => 'unauthorized')
+      end
+
+      it 'returns 401 with a wrong token of the same length' do
+        expect(request(headers: { 'HTTP_AUTHORIZATION' => 'Bearer nekret' }).first).to eq(401)
+      end
+
+      it 'returns 401 with a non-Bearer Authorization header' do
+        expect(request(headers: { 'HTTP_AUTHORIZATION' => 'Basic sekret' }).first).to eq(401)
+      end
+
+      it 'accepts the correct bearer token' do
+        expect(request(headers: { 'HTTP_AUTHORIZATION' => 'Bearer sekret' }).first).to eq(200)
+      end
+
+      it 'accepts the correct token query param' do
+        expect(request(query: 'token=sekret').first).to eq(200)
+      end
+    end
+
+    context 'when MONITORING_TOKEN is blank' do
+      it 'allows access when unset' do
+        stub_env('MONITORING_TOKEN' => nil)
+        expect(request.first).to eq(200)
+      end
+
+      it 'allows access when empty' do
+        stub_env('MONITORING_TOKEN' => '')
+        expect(request.first).to eq(200)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Note: This *may* be something that would be valuable to commit back to Hyku, but I'm honestly not sure yet - I want to see it in action for a few weeks on production before I decide.

# Story
A lot of our downtimes are due to Bots, which exhaust our Puma threads, increase the queue length, which leads to slower and slower response times, which leads to downtime.

If we monitor the queue length itself, we may be able to intervene before it becomes a downtime, understand *why* the app is down more quickly, as well as be able to better configure our applications based on the information.

# Expected Behavior Before Changes
No way to monitor puma queue

# Expected Behavior After Changes
Can query an endpoint to get the puma queue length

Currently deployed to friends - check https://hykuup-knapsack-friends.notch8.cloud/monitoring/puma_stats
