### PR TITLE
Fix production redis OOM crash loop (memory limit, eviction policy, broken session namespacing)

### DIFF
--- a/app/parsers/bulkrax/csv_parser_decorator.rb
+++ b/app/parsers/bulkrax/csv_parser_decorator.rb
@@ -155,6 +155,7 @@ module Bulkrax
       CSV.foreach(csv_file_paths.first, headers: true) do |csv_row|
         return true if csv_row['ss_pid'] == row['ss_pid']
       end
+      false
     end
   end
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+# OVERRIDE Hyku (samvera/hyku@ddd0c4c785c28a08cbbd0e12ac1d092f0ec4d4d8) - fix
+# broken redis session namespacing.
+#
+# The upstream initializer passes `url: session_url` to `config.session_store
+# :redis_store`, but neither ActionDispatch::Session::RedisStore#initialize
+# nor Redis::Rack::Connection#store ever read `:url` - only `:redis_server`
+# (or `:servers`, mapped from `:redis_server`). Because of that, the intended
+# "/session" namespace segment on session_url is silently dropped: the
+# connection falls back to Redis::Store::Factory.create(nil) -> Redis::Store.new({})
+# -> the redis gem's own ENV['REDIS_URL'] fallback, so sessions land in the
+# right redis instance but with NO namespace - indistinguishable from other
+# keys sharing the same db (this took down main.hykuup.com when that shared
+# redis OOM'd). Passing `redis_server:` instead routes through
+# Redis::Store::Factory's URL parsing, which does split the
+# "/session" path segment into a real namespace, restoring "session:*" keys.
+#
+# Remove when: fixed upstream in samvera/hyku.
+redis_url = ENV.fetch('REDIS_URL', false)
+if redis_url
+  session_url = "#{redis_url}/session"
+  secure = Rails.env.production? || Rails.env&.staging?
+  key = Rails.env.production? ? "_hyku_session" : "_hyku_session_#{Rails.env}"
+
+  Rails.application.config.session_store :redis_store,
+    redis_server: session_url,
+    expire_after: 1.day,
+    key:,
+    threadsafe: true,
+    secure:,
+    same_site: :lax,
+    httponly: true
+else
+  Rails.application.config.session_store :cookie_store, key: '_hyku_session'
+end

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -269,12 +269,27 @@ redis:
     tag: 7.0.2-debian-11-r7
   architecture: standalone
   master:
+    # maxmemory kept below the container limit so Redis evicts stale cache
+    # entries under its own eviction policy instead of relying solely on the
+    # container limit + kernel OOM killer.
+    # volatile-lru: ~98.5% of current keys already carry a TTL (long-dated
+    # Rails.cache entries), so this evicts from that pool under pressure
+    # without touching the small fraction of keys with no expiry at all.
+    configuration: |-
+      maxmemory 2gb
+      maxmemory-policy volatile-lru
+    # TODO: shrink limit/request to 3072Mi/2560Mi (headroom above maxmemory,
+    # rather than an independent ceiling) once a deploy with maxmemory has
+    # been running healthily in production for a while. Left matching the
+    # current live 4Gi/2Gi for now so this PR only adds the eviction policy
+    # on the next deploy, without also surprise-shrinking an already-running
+    # container's memory ceiling in the same step.
     resources:
       limits:
-        memory: "2048Mi"
+        memory: "4096Mi"
         cpu: "100m"
       requests:
-        memory: "1024Mi"
+        memory: "2048Mi"
         cpu: "20m"
     persistence:
       enabled: true

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -268,7 +268,7 @@ redis:
   architecture: standalone
   auth:
     password: $REDIS_PASSWORD
-  
+
 solr:
   enabled: false
 

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -252,6 +252,12 @@ redis:
     tag: 7.0.2-debian-11-r7
   enabled: true
   master:
+    # Testing the maxmemory/eviction fix from the 2026-07-29 production redis
+    # OOM incident here before rolling it out further. 384mb leaves headroom
+    # under the 512Mi container limit.
+    configuration: |-
+      maxmemory 384mb
+      maxmemory-policy volatile-lru
     resources:
       limits:
         memory: "512Mi"
@@ -262,6 +268,7 @@ redis:
   architecture: standalone
   auth:
     password: $REDIS_PASSWORD
+  
 solr:
   enabled: false
 


### PR DESCRIPTION
## Summary

Production redis (`hykuup-knapsack-production-redis-master-0`) was stuck in a `CrashLoopBackOff` (repeated `OOMKilled`), taking down `main.hykuup.com` on every request that touched the session. This PR contains the fixes developed and verified during that incident, plus an unrelated CI-blocking test fix bundled in so this PR can actually go green.

- **Redis maxmemory + eviction policy** (`ops/production-deploy.tmpl.yaml`, `ops/staging-deploy.tmpl.yaml`): the dataset had no `maxmemory`/eviction policy (`noeviction`, unlimited) and outgrew the container's memory limit, so the kernel OOM-killed it every restart with no way to self-heal. Added `maxmemory 2gb` / `maxmemory-policy volatile-lru`. Production's container limit/request are left matching what's *currently live* (4Gi/2Gi, the emergency bump applied during the incident) rather than also shrinking them in this PR - so the next production deploy only adds the eviction policy, without a surprise reduction to an already-running container's memory ceiling in the same step. There's a TODO to shrink it to 3072Mi/2560Mi (sized as headroom above `maxmemory` rather than an independent ceiling) once this has run healthily in production for a while. Staging gets a scaled-down version (512Mi limit, 384mb maxmemory) so this can be exercised on a non-production environment now.
- **Broken session namespacing** (`config/initializers/session_store.rb`, new file): traced the dominant share of redis keys to *unnamespaced Rack sessions*, not `Rails.cache` as first suspected. The upstream initializer (`samvera/hyku@ddd0c4c785c`) passes `url:` to the redis session store, but the actual connection-building code (`ActionDispatch::Session::RedisStore`, `Redis::Rack::Connection`) only ever reads `:redis_server`. The intended `/session` namespace was silently dropped, so sessions landed in the right redis instance but as bare, unprefixed keys indistinguishable from everything else sharing the same db. Fixed via the knapsack's existing `hyku_knapsack.load_initializers` override mechanism (no upstream/submodule edit needed).
- **Shortened session `expire_after`** from 180 days to 1 day: Devise's `:rememberable` module already handles long-term "stay logged in" independently (2-week signed remember-me cookie), so the raw session mostly needs to cover CSRF/flash/search-state for one visit. A near-permanent TTL meant every disposable crawler/bot session (the majority of traffic on a public, crawler-heavy site) piled up in redis for the better part of a year instead of aging out day to day.
- **Fixed a pre-existing, unrelated CI failure** (`app/parsers/bulkrax/csv_parser_decorator.rb`): `in_collection_and_community?` had no explicit final return, so it fell through to whatever `CSV.foreach(...) { block }` happens to return when the block never hits `return true` (an integer with the currently-installed `csv` gem, not `nil` as the code implicitly assumed) - a truthy non-boolean, so every row was misclassified as the collection model instead of `MobiusWork`. Bundled into this PR since CI needs to be green for the redis fix to merge; unrelated to the incident itself.

## Verification

- Memory limit + eviction policy: confirmed live on production during the incident (stable at `1/1 Ready`, 0 restarts) and separately verified on staging (`INFO memory` shows `maxmemory_policy:volatile-lru` as configured).
- Session namespacing fix: verified via `rails runner` in a dev container (corrected option produces a real `session:<sid>` key vs. a bare one with the original bug), and confirmed on a real staging deploy - a fresh HTTP request produces a `session:2::<hash>` key, visibly distinct from thousands of pre-existing unprefixed keys in that same staging redis from before the fix.
- Shortened expiry: confirmed on staging - a session created after this deploy has `TTL≈86400s` (1 day) vs. ~180 days for sessions created before it.
- CSV parser fix: reproduced the exact CI failure locally (`bundle exec rspec spec/parsers/bulkrax/csv_parser_decorator_spec.rb spec/helpers/hyrax/blacklight_override_decorator_spec.rb spec/hyku_knapsack/application_spec.rb spec/indexers/scholarly_work_indexer_spec.rb --seed 26096`, run from `/app/samvera` to match CI's actual bundle/gem context) and confirmed the fix resolves it: 18 examples, 0 failures, vs. 1 failure before.

## Not included here

- Production has only received the emergency live memory-limit bump (2Gi→4Gi) applied via `kubectl patch` during the incident, plus this PR's unchanged 4Gi/2Gi limit/request - the `maxmemory`/eviction policy, session namespacing fix, and shortened expiry in this PR have been tested on staging only, not yet deployed to production.
- Once this deploys to production and runs healthily for a while: shrink the production redis memory limit/request per the TODO in `ops/production-deploy.tmpl.yaml`.
- A follow-up upstream contribution to `samvera/hyrax`'s Helm chart (defaulting `maxmemory`/`maxmemory-policy` for its bundled redis dependency) was discussed but not started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)