### PR TITLE
Fix websocket-services issue

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -59,6 +59,7 @@ ingress:
   annotations: {
     nginx.org/client-max-body-size: "0",
     nginx.org/proxy-connect-timeout: "120s",
+    nginx.org/websocket-services: "hykuup-knapsack-production-nginx",
     cert-manager.io/cluster-issuer: letsencrypt-production-dns
   }
   tls:
@@ -366,6 +367,11 @@ nginx:
 
     error_log  /opt/bitnami/nginx/logs/error.log warn;
 
+    # Lets ActionCable's websocket handshake upgrade instead of falling through to a plain HTTP request Rails 404s.
+    map ${DOLLAR}http_upgrade ${DOLLAR}connection_upgrade {
+        default upgrade;
+        ''      '';
+    }
     # Cloudflare ips see for refresh
     # https://support.cloudflare.com/hc/en-us/articles/200170786-Restoring-original-visitor-IPs-logging-visitor-IP-addresses
     # update list https://www.cloudflare.com/ips/

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -59,6 +59,7 @@ ingress:
         - path: /
   annotations: {
     nginx.org/client-max-body-size: "0",
+    nginx.org/websocket-services: "hykuup-knapsack-staging-nginx",
     cert-manager.io/cluster-issuer: letsencrypt-production-dns
   }
   tls:
@@ -351,6 +352,12 @@ nginx:
                       'referer="${DOLLAR}http_referer" agent="${DOLLAR}http_user_agent" request_time=${DOLLAR}request_time upstream_response_time=${DOLLAR}upstream_response_time upstream_response_length=${DOLLAR}upstream_response_length';
 
     error_log  /opt/bitnami/nginx/logs/error.log warn;
+
+    # Lets ActionCable's websocket handshake upgrade instead of falling through to a plain HTTP request Rails 404s.
+    map ${DOLLAR}http_upgrade ${DOLLAR}connection_upgrade {
+        default upgrade;
+        ''      '';
+    }
 
     # Cloudflare ips see for refresh
     # https://support.cloudflare.com/hc/en-us/articles/200170786-Restoring-original-visitor-IPs-logging-visitor-IP-addresses

--- a/spec/helpers/hyrax/blacklight_override_decorator_spec.rb
+++ b/spec/helpers/hyrax/blacklight_override_decorator_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe Hyrax::BlacklightOverride, type: :helper do
   let(:field_name) { 'title_tesim' }
   let(:document) { instance_double(SolrDocument, to_h: {}) }
 
-  def index_fields(_document)
-    CatalogController.blacklight_config.index_fields
+  def blacklight_config
+    CatalogController.blacklight_config
   end
 
   context "when locale is :en" do


### PR DESCRIPTION
Without this change, the rails server serves all of the notification update requests, instead of it getting put on its own thread. This clogs up Puma threads, which are a performance bottleneck right now.

Connected to https://github.com/notch8/dev-ops/issues/1408