### PR TITLE
Add a consortium-grouped deploy check

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ include making contributing back to the Hyku project easier and making upgrades 
 
 ### Version strategy
 
-Hyku Knapsack versions are aligned with [Hyku](https://github.com/samvera/hyku) versions: **Knapsack 6** works with the **Hyku 6** series, **Knapsack 7** with the **Hyku 7** series (which introduces breaking changes), and so on. That way you can tell at a glance which Knapsack release to use for a given Hyku version. Pick the Knapsack major version that matches your Hyku major version.
+This repository is HykuUp's deployment of Hyku, and it is versioned on **HykuUp's own line** — `v1.0-prod-baseline`, then `v1.1.0`, and so on. The version says nothing about which Hyku series is pinned, so every release states the Hyku and Hyrax versions it ships in the release body. `lib/hyku_knapsack/version.rb` carries the same number as the release tag.
+
+Upstream [samvera-labs/hyku_knapsack](https://github.com/samvera-labs/hyku_knapsack) uses a different rule, where the Knapsack major matches the Hyku major (Knapsack 7 for the Hyku 7 series). That rule is not followed here: HykuUp has never had a 6 or a 7, and borrowing Hyku's number would imply releases that do not exist.
 
 ### Precedence
 

--- a/bin/deploy-check/README.md
+++ b/bin/deploy-check/README.md
@@ -65,6 +65,30 @@ update its work types. Both have to be set. The snapshot records
   `qa_local_authority_entries`; `bin/helm_deploy` runs with `--atomic --timeout 15m0s`.
 - **Behaviour under load.**
 
+## Consortium check
+
+`consortium_check.rb` groups tenants by consortium instead of listing them
+individually, which is the question that matters when a deploy touches work type
+or metadata profile resolution: not "did this tenant change" but "is every Mobius
+tenant still coherent".
+
+```bash
+kubectl --context $CTX -n $NS exec -i $POD -- bundle exec rails runner - \
+  < bin/deploy-check/consortium_check.rb
+```
+
+It fails when a consortium tenant resolves a profile other than its own
+consortium's, or when a tenant offers a work type that has no class in its
+metadata profile.
+
+That second case is not cosmetic. A work type in `available_works` with no class
+in the tenant's flexible schema never receives the metadata mixin, so building
+its form raises `NoMethodError: undefined method 'depositor'` and the depositor
+gets a 500. As of 2026-08-26 that affects nine production tenants, all of them
+`consortia=nil` or `stjude` offering `MobiusWork`/`ScholarlyWork`. Pre-existing,
+and a deploy cannot change it, since nothing recomputes `available_works` - which
+is why the pre-deploy capture is worth keeping until someone fixes the config.
+
 ## Baselines
 
 `baselines/` holds the capture taken immediately before a production deploy, kept

--- a/bin/deploy-check/README.md
+++ b/bin/deploy-check/README.md
@@ -14,19 +14,25 @@ deploy log. `snapshot.rb` captures the state that matters per tenant, and
 
 ```bash
 CTX=r2-besties; NS=hykuup-knapsack-production
-POD=$(kubectl --context $CTX -n $NS get pods --no-headers | awk '/-hyrax-[0-9a-f]/{print $1; exit}')
+# Excludes components rather than matching a name: the web deployment is named
+# `-hyrax-` on some environments and bare on others.
+POD() { kubectl --context $CTX -n $NS get pods --no-headers | grep -E '\sRunning\s' \
+  | grep -vE 'worker|nginx|solr|fcrepo|postgres|redis|memcach|acme|fits|sidekiq|cron' \
+  | awk '{print $1; exit}'; }
 
 # Before the deploy
-kubectl --context $CTX -n $NS exec -i $POD -- bundle exec rails runner - \
-  < bin/deploy-check/snapshot.rb > before.json
+kubectl --context $CTX -n $NS exec -i $(POD) -- bundle exec rails runner - \
+  < bin/deploy-check/snapshot.rb | sed -n '/^{/,$p' > before.json
 
-# After (pod name changes - re-resolve it first)
-POD=$(kubectl --context $CTX -n $NS get pods --no-headers | awk '/-hyrax-[0-9a-f]/{print $1; exit}')
-kubectl --context $CTX -n $NS exec -i $POD -- bundle exec rails runner - \
-  < bin/deploy-check/snapshot.rb > after.json
+# After (the deploy replaces the pod, so POD is re-resolved)
+kubectl --context $CTX -n $NS exec -i $(POD) -- bundle exec rails runner - \
+  < bin/deploy-check/snapshot.rb | sed -n '/^{/,$p' > after.json
 
 bin/deploy-check/compare.rb before.json after.json
 ```
+
+The `sed` strips Rails boot warnings that precede the JSON — without it the file
+will not parse.
 
 `snapshot.rb` is strictly read-only. Non-zero exit means something in the
 must-not-change set moved.

--- a/bin/deploy-check/README.md
+++ b/bin/deploy-check/README.md
@@ -31,7 +31,7 @@ kubectl --context $CTX -n $NS exec -i $(POD) -- bundle exec rails runner - \
 bin/deploy-check/compare.rb before.json after.json
 ```
 
-The `sed` strips Rails boot warnings that precede the JSON — without it the file
+The `sed` strips Rails boot warnings that precede the JSON; without it the file
 will not parse.
 
 `snapshot.rb` is strictly read-only. Non-zero exit means something in the
@@ -41,8 +41,8 @@ must-not-change set moved.
 
 A deploy should never change these on its own:
 
-- `available_works` — a tenant's depositors gaining or losing work types
-- `consortia`, `profile_path` — consortium membership, or which m3 profile resolves
+- `available_works`: a tenant's depositors gaining or losing work types
+- `consortia`, `profile_path`: consortium membership, or which m3 profile resolves
 - `themes`, `schema_classes`, `features`
 - a tenant disappearing, newly erroring, or a sample work losing its thumbnail
 - global registered work types, derivative labels, viewer and manifest config
@@ -54,14 +54,14 @@ and Puma versions, and any key the previous version could not report at all.
 
 `Site#available_works` is a persisted column seeded only when the Site row is
 created (`Site.instance` uses `first_or_create`). Nothing recomputes it at boot
-or during migration, so a deploy alone cannot change it — which is exactly why a
+or during migration, so a deploy alone cannot change it, which is exactly why a
 change there means something wrote to it.
 
 The corollary: assigning `part_of_consortia` to an existing tenant does **not**
 update its work types. Both have to be set. The snapshot records
 `available_works` and `allowed_by_consortium` separately so the gap is visible.
 
-## Not covered — check these by hand
+## Not covered, check these by hand
 
 - **Static assets.** Fetch the homepage and confirm the fingerprinted
   `/assets/application-*.css` and `.js` return 200. The nginx image bakes assets

--- a/bin/deploy-check/README.md
+++ b/bin/deploy-check/README.md
@@ -89,6 +89,33 @@ gets a 500. As of 2026-08-26 that affects nine production tenants, all of them
 and a deploy cannot change it, since nothing recomputes `available_works` - which
 is why the pre-deploy capture is worth keeping until someone fixes the config.
 
+## Sequence check
+
+`sequence_check.rb` reports any tenant whose `id` sequence has fallen behind
+`max(id)`. When that happens the next insert reuses an existing id and Postgres
+raises `PG::UniqueViolation` on the primary key - which surfaces as a failed
+metadata profile import or vocabulary create, with nothing obviously wrong in the
+logs. It reads `last_value` rather than calling `nextval`, so it consumes nothing.
+
+```bash
+kubectl --context $CTX -n $NS exec -i $POD -- bundle exec rails runner - \
+  < bin/deploy-check/sequence_check.rb
+```
+
+Worth running before a deploy that will insert into these tables, since a desync
+is easy to mistake for deploy fallout. As of 2026-08-26 every HykuUp tenant in
+staging and production is clear, with sequences comfortably ahead of max(id).
+
+To repair a tenant that is behind:
+
+```ruby
+%w[hyrax_flexible_schemas qa_local_authorities qa_local_authority_entries].each do |t|
+  ActiveRecord::Base.connection.execute(
+    "SELECT setval(pg_get_serial_sequence('#{t}','id'), (SELECT COALESCE(MAX(id),1) FROM #{t}))"
+  )
+end
+```
+
 ## Baselines
 
 `baselines/` holds the capture taken immediately before a production deploy, kept

--- a/bin/deploy-check/SKILL.md
+++ b/bin/deploy-check/SKILL.md
@@ -9,7 +9,7 @@ Copy this file to `.claude/skills/deploy-regression-check/SKILL.md` in your repo
 invoke it as `/deploy-regression-check`, or just follow the steps below.
 
 A knapsack deploy can change tenant behaviour without anything appearing in the
-deploy log — 30-odd tenants is too many to eyeball. `snapshot.rb` records the state
+deploy log, and 30-odd tenants is too many to eyeball. `snapshot.rb` records the state
 that matters per tenant; `compare.rb` diffs a before and after capture and exits
 non-zero if anything in the must-not-change set moved.
 
@@ -20,8 +20,8 @@ afterwards.
 
 `snapshot.rb`, `compare.rb` and `sequence_check.rb` work on any Hyku Knapsack.
 Knapsack-specific classes are guarded, so a repo without them simply records fewer
-keys rather than failing. `consortium_check.rb` is HykuUp-specific — it depends on
-`TenantWorkTypeFilter` and `Consortium` — and can be ignored elsewhere.
+keys rather than failing. `consortium_check.rb` is HykuUp-specific: it depends on
+`TenantWorkTypeFilter` and `Consortium`, and can be ignored elsewhere.
 
 Scripts are piped over stdin, so they run from your local checkout and never need
 to be in the deployed image.
@@ -50,12 +50,12 @@ kubectl --context $CTX -n $NS exec -i $(POD) -- bundle exec rails runner - \
   < bin/deploy-check/sequence_check.rb
 ```
 
-The `sed` strips Rails boot warnings that precede the JSON — without it the file
+The `sed` strips Rails boot warnings that precede the JSON; without it the file
 will not parse.
 
 **2. Deploy.**
 
-**3. After the deploy** — re-resolve the pod, since the deploy replaced it:
+**3. After the deploy**, re-resolve the pod, since the deploy replaced it:
 
 ```bash
 kubectl --context $CTX -n $NS exec -i $(POD) -- bundle exec rails runner - \
@@ -66,9 +66,9 @@ bin/deploy-check/compare.rb before.json after.json
 
 ## Reading the output
 
-Fails the check — a deploy should never change these on its own:
+Fails the check. A deploy should never change these on its own:
 
-- `available_works` — a tenant's depositors gaining or losing work types
+- `available_works`: a tenant's depositors gaining or losing work types
 - `themes`, `schema_classes`
 - an existing feature flag whose **value** changed
 - a tenant disappearing, newly erroring, or a sample work losing its thumbnail
@@ -82,23 +82,40 @@ that is not a regression), and any key the previous version could not report.
 Identical findings across many tenants collapse to one line with a count, so a
 fleet-wide change reads as one finding rather than thirty.
 
-A non-zero exit means look closer, not necessarily that something broke — an
+A non-zero exit means look closer, not necessarily that something broke; an
 intended change like flipping a config flag will also fail the check, which is
 correct. Read the three-or-so distinct lines and decide.
 
-## Also worth checking by hand
+**4. Browser pass on a few tenants**
 
-The snapshot cannot see these:
+The snapshot reads the database and Solr; it never renders a page. A partial that
+raises, a viewer that fails to initialise, a stylesheet that 404s and a card that
+renders blank are all invisible to it. Drive a browser with the Playwright MCP
+server before and after, on the same short list both times:
+
+> Using Playwright, log in as an admin on <tenant URL> and visit the homepage, a
+> work show page, the deposit form and the dashboard. Screenshot each and note
+> anything that renders empty or errors. Save them so we can repeat this exact
+> list after the deploy and compare.
+
+Pick three or four tenants, not the fleet: one plain, one with a custom theme, and
+whichever has the configuration you are least sure about. This is judgement rather
+than a gate, so it produces screenshots and an opinion, not an exit code. It covers
+what `compare.rb` structurally cannot.
+
+## Also worth checking by hand
 
 - **Static assets.** Fetch the homepage, extract the fingerprinted
   `/assets/application-*.css`, and confirm it returns 200. If the nginx image bakes
   assets at build time, a bad build shows up as an unstyled site, not an error.
+  The browser pass shows this on the pages you visit; this covers the rest.
 - **Migration duration**, against whatever `--timeout` `bin/helm_deploy` uses.
-- **Behaviour under load.**
+- **Behaviour under load.** The snapshot is one quiet request and the browser pass
+  is one session.
 
 ## Why `available_works` is the one to watch
 
 `Site#available_works` is a persisted column seeded only when the Site row is
 created (`Site.instance` uses `first_or_create`). Nothing recomputes it at boot or
-during migration, so a deploy alone cannot change it — which is exactly why a change
+during migration, so a deploy alone cannot change it, which is exactly why a change
 there means something wrote to it, and is worth failing on.

--- a/bin/deploy-check/SKILL.md
+++ b/bin/deploy-check/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: deploy-regression-check
+description: Capture per-tenant behaviour before a Hyku Knapsack deploy and diff it afterwards to catch silent regressions. Use when deploying a knapsack to production or staging, bumping the hyrax-webapp submodule, or when asked to verify a deploy caused no tenant-level regressions.
+---
+
+# Deploy regression check
+
+Copy this file to `.claude/skills/deploy-regression-check/SKILL.md` in your repo to
+invoke it as `/deploy-regression-check`, or just follow the steps below.
+
+A knapsack deploy can change tenant behaviour without anything appearing in the
+deploy log — 30-odd tenants is too many to eyeball. `snapshot.rb` records the state
+that matters per tenant; `compare.rb` diffs a before and after capture and exits
+non-zero if anything in the must-not-change set moved.
+
+**The baseline has to be captured before the deploy.** It cannot be reconstructed
+afterwards.
+
+## Portability
+
+`snapshot.rb`, `compare.rb` and `sequence_check.rb` work on any Hyku Knapsack.
+Knapsack-specific classes are guarded, so a repo without them simply records fewer
+keys rather than failing. `consortium_check.rb` is HykuUp-specific — it depends on
+`TenantWorkTypeFilter` and `Consortium` — and can be ignored elsewhere.
+
+Scripts are piped over stdin, so they run from your local checkout and never need
+to be in the deployed image.
+
+## Steps
+
+Set the context and namespace for the environment you are deploying:
+
+```bash
+CTX=<kubectl-context>; NS=<namespace>
+POD() { kubectl --context $CTX -n $NS get pods --no-headers | awk '/-hyrax-[0-9a-f]/{print $1; exit}'; }
+```
+
+**1. Before the deploy**
+
+```bash
+kubectl --context $CTX -n $NS exec -i $(POD) -- bundle exec rails runner - \
+  < bin/deploy-check/snapshot.rb | sed -n '/^{/,$p' > before.json
+
+# optional, catches a class of failure that looks like deploy fallout but isn't
+kubectl --context $CTX -n $NS exec -i $(POD) -- bundle exec rails runner - \
+  < bin/deploy-check/sequence_check.rb
+```
+
+The `sed` strips Rails boot warnings that precede the JSON — without it the file
+will not parse.
+
+**2. Deploy.**
+
+**3. After the deploy** — re-resolve the pod, since the deploy replaced it:
+
+```bash
+kubectl --context $CTX -n $NS exec -i $(POD) -- bundle exec rails runner - \
+  < bin/deploy-check/snapshot.rb | sed -n '/^{/,$p' > after.json
+
+bin/deploy-check/compare.rb before.json after.json
+```
+
+## Reading the output
+
+Fails the check — a deploy should never change these on its own:
+
+- `available_works` — a tenant's depositors gaining or losing work types
+- `themes`, `schema_classes`
+- an existing feature flag whose **value** changed
+- a tenant disappearing, newly erroring, or a sample work losing its thumbnail
+- global registered work types, derivative labels, viewer and manifest config
+- on HykuUp also `consortia` and `profile_path`
+
+Reported but not failed: counts, vocabulary term counts, schema version, Hyrax and
+Puma versions, **feature flags that appeared or vanished** (an upgrade adds flags;
+that is not a regression), and any key the previous version could not report.
+
+Identical findings across many tenants collapse to one line with a count, so a
+fleet-wide change reads as one finding rather than thirty.
+
+A non-zero exit means look closer, not necessarily that something broke — an
+intended change like flipping a config flag will also fail the check, which is
+correct. Read the three-or-so distinct lines and decide.
+
+## Also worth checking by hand
+
+The snapshot cannot see these:
+
+- **Static assets.** Fetch the homepage, extract the fingerprinted
+  `/assets/application-*.css`, and confirm it returns 200. If the nginx image bakes
+  assets at build time, a bad build shows up as an unstyled site, not an error.
+- **Migration duration**, against whatever `--timeout` `bin/helm_deploy` uses.
+- **Behaviour under load.**
+
+## Why `available_works` is the one to watch
+
+`Site#available_works` is a persisted column seeded only when the Site row is
+created (`Site.instance` uses `first_or_create`). Nothing recomputes it at boot or
+during migration, so a deploy alone cannot change it — which is exactly why a change
+there means something wrote to it, and is worth failing on.

--- a/bin/deploy-check/SKILL.md
+++ b/bin/deploy-check/SKILL.md
@@ -32,7 +32,11 @@ Set the context and namespace for the environment you are deploying:
 
 ```bash
 CTX=<kubectl-context>; NS=<namespace>
-POD() { kubectl --context $CTX -n $NS get pods --no-headers | awk '/-hyrax-[0-9a-f]/{print $1; exit}'; }
+# Excludes components rather than matching a name: the web deployment is named
+# `-hyrax-` on some environments and bare on others.
+POD() { kubectl --context $CTX -n $NS get pods --no-headers | grep -E '\sRunning\s' \
+  | grep -vE 'worker|nginx|solr|fcrepo|postgres|redis|memcach|acme|fits|sidekiq|cron' \
+  | awk '{print $1; exit}'; }
 ```
 
 **1. Before the deploy**

--- a/bin/deploy-check/baselines/production-2026-08-26-consortium-pre-v7.2.0.txt
+++ b/bin/deploy-check/baselines/production-2026-08-26-consortium-pre-v7.2.0.txt
@@ -1,0 +1,110 @@
+Defaulted container "hyrax" out of: hyrax, load-solr-config (init), db-setup (init), sync-static-assets (init)
+/usr/local/bundle/gems/bundler-2.6.9/lib/bundler/rubygems_ext.rb:64: warning: already initialized constant Gem::Platform::JAVA
+/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/platform.rb:279: warning: previous definition of JAVA was here
+/usr/local/bundle/gems/bundler-2.6.9/lib/bundler/rubygems_ext.rb:65: warning: already initialized constant Gem::Platform::MSWIN
+/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/platform.rb:280: warning: previous definition of MSWIN was here
+/usr/local/bundle/gems/bundler-2.6.9/lib/bundler/rubygems_ext.rb:66: warning: already initialized constant Gem::Platform::MSWIN64
+/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/platform.rb:281: warning: previous definition of MSWIN64 was here
+/usr/local/bundle/gems/bundler-2.6.9/lib/bundler/rubygems_ext.rb:67: warning: already initialized constant Gem::Platform::MINGW
+/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/platform.rb:282: warning: previous definition of MINGW was here
+/usr/local/bundle/gems/bundler-2.6.9/lib/bundler/rubygems_ext.rb:68: warning: already initialized constant Gem::Platform::X64_MINGW
+/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/platform.rb:284: warning: previous definition of X64_MINGW was here
+/usr/local/bundle/gems/bundler-2.6.9/lib/bundler/rubygems_ext.rb:70: warning: already initialized constant Gem::Platform::UNIVERSAL_MINGW
+/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/platform.rb:285: warning: previous definition of UNIVERSAL_MINGW was here
+/usr/local/bundle/gems/bundler-2.6.9/lib/bundler/rubygems_ext.rb:71: warning: already initialized constant Gem::Platform::WINDOWS
+/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/platform.rb:286: warning: previous definition of WINDOWS was here
+/usr/local/bundle/gems/bundler-2.6.9/lib/bundler/rubygems_ext.rb:72: warning: already initialized constant Gem::Platform::X64_LINUX
+/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/platform.rb:287: warning: previous definition of X64_LINUX was here
+/usr/local/bundle/gems/bundler-2.6.9/lib/bundler/rubygems_ext.rb:73: warning: already initialized constant Gem::Platform::X64_LINUX_MUSL
+/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/platform.rb:288: warning: previous definition of X64_LINUX_MUSL was here
+[DEPRECATION] PCDM is deprecating 'Valkyrie::Vocab::PCDMUse#PreservationMasterFile'. Use 'Valkyrie::Vocab::PCDMUse#PreservationFile' instead. This warning does *not* indicate that usage of the deprecated term has been detected.
+DEPRECATION WARNING: You are using deprecated behavior which will be removed from the next major or minor release. (called from block (2 levels) in <class:Engine> at /usr/local/bundle/gems/iiif_print-3.0.12/lib/iiif_print/engine.rb:67)
+/app/samvera/config/initializers/hyrax.rb:7: warning: already initialized constant HykuKnapsack::DEFAULT_M3_PROFILE_PATH
+/app/samvera/config/initializers/hyrax.rb:7: warning: previous definition of DEFAULT_M3_PROFILE_PATH was here
+/app/samvera/config/initializers/knapsack_authorities.rb:12: warning: already initialized constant HykuKnapsack::AUTHORITIES_PATH
+/app/samvera/config/initializers/knapsack_authorities.rb:12: warning: previous definition of AUTHORITIES_PATH was here
+DEPRECATION WARNING: ActiveFedora and Wings will be removed from a future major release of Hyrax in favor of Valkyrie resource models. Please migrate your models from ActiveFedora::Base to Hyrax::Resource. (called from <module:Wings> at /usr/local/bundle/bundler/gems/hyrax-c2b18e57523a/lib/wings.rb:64)
+I, [2026-08-26T16:33:19.068462 #59957]  INFO -- : ActiveFedora: loading fedora config from /app/samvera/hyrax-webapp/config/fedora.yml
+I, [2026-08-26T16:33:19.069608 #59957]  INFO -- : ActiveFedora: loading solr config from /app/samvera/hyrax-webapp/config/solr.yml
+DEPRECATION WARNING: Hyrax::DerivativeService.services is deprecated; favor Hyrax.config.derivative_servies. (called from services at /usr/local/bundle/bundler/gems/hyrax-c2b18e57523a/app/services/hyrax/derivative_service.rb:22)
+W, [2026-08-26T16:33:19.922770 #59957]  WARN -- : Same predicate (http://purl.org/dc/terms/accessRights) used for properties additional_information and access_right
+W, [2026-08-26T16:33:19.927856 #59957]  WARN -- : Same predicate (http://purl.org/dc/terms/bibliographicCitation) used for properties bibliographic_citation and bibliographic_citation
+W, [2026-08-26T16:33:19.959572 #59957]  WARN -- : Same predicate (http://purl.org/dc/terms/accessRights) used for properties additional_information and access_right
+W, [2026-08-26T16:33:19.963514 #59957]  WARN -- : Same predicate (http://purl.org/dc/terms/bibliographicCitation) used for properties bibliographic_citation and bibliographic_citation
+DEPRECATION WARNING: Blacklight::Base is deprecated and will be removed in Blacklight 8.0.0.
+	Include Blacklight::Configurable and Blacklight::SearchContext as needed (included in Blacklight::Catalog). (called from included at /usr/local/bundle/gems/blacklight-7.41.0/app/controllers/concerns/blacklight/base.rb:9)
+DEPRECATION WARNING: Blacklight::Base is deprecated and will be removed in Blacklight 8.0.0.
+	Include Blacklight::Configurable and Blacklight::SearchContext as needed (included in CatalogController). (called from included at /usr/local/bundle/gems/blacklight-7.41.0/app/controllers/concerns/blacklight/base.rb:9)
+DEPRECATION WARNING: Blacklight::AccessControls::Enforcement is deprecated and will be removed in 1.0. (called from block in <module:Enforcement> at /usr/local/bundle/gems/blacklight-access_controls-6.1.0/lib/blacklight/access_controls/enforcement.rb:23)
+DEPRECATION WARNING: Blacklight::Base is deprecated and will be removed in Blacklight 8.0.0.
+	Include Blacklight::Configurable and Blacklight::SearchContext as needed (included in Hyrax::MyController). (called from included at /usr/local/bundle/gems/blacklight-7.41.0/app/controllers/concerns/blacklight/base.rb:9)
+/app/samvera/hyrax-webapp/app/services/hyrax/collection_types/create_service_decorator.rb:151: warning: already initialized constant Hyrax::CollectionTypes::CreateService::DEFAULT_OPTIONS
+/usr/local/bundle/bundler/gems/hyrax-c2b18e57523a/app/services/hyrax/collection_types/create_service.rb:15: warning: previous definition of DEFAULT_OPTIONS was here
+/app/samvera/hyrax-webapp/app/services/hyrax/collection_types/create_service_decorator.rb:152: warning: already initialized constant Hyrax::CollectionTypes::CreateService::USER_COLLECTION_OPTIONS
+/usr/local/bundle/bundler/gems/hyrax-c2b18e57523a/app/services/hyrax/collection_types/create_service.rb:33: warning: previous definition of USER_COLLECTION_OPTIONS was here
+/usr/local/bundle/bundler/gems/hyrax-c2b18e57523a/app/services/hyrax/user_stat_importer.rb:6: warning: redefining constant Struct::UserRecord
+DEPRECATION WARNING: Hyrax::DerivativeService.services= is deprecated; favor Hyrax.config.derivative_servies=. (called from services= at /usr/local/bundle/bundler/gems/hyrax-c2b18e57523a/app/services/hyrax/derivative_service.rb:16)
+DEPRECATION WARNING: Blacklight::Base is deprecated and will be removed in Blacklight 8.0.0.
+	Include Blacklight::Configurable and Blacklight::SearchContext as needed (included in Hyrax::IiifAv::IiifAvController). (called from included at /usr/local/bundle/gems/blacklight-7.41.0/app/controllers/concerns/blacklight/base.rb:9)
+DEPRECATION WARNING: Blacklight::AccessControls::Enforcement is deprecated and will be removed in 1.0. (called from block in <module:Enforcement> at /usr/local/bundle/gems/blacklight-access_controls-6.1.0/lib/blacklight/access_controls/enforcement.rb:23)
+I, [2026-08-26T16:33:31.345143 #59957]  INFO -- : Hyrax::Engine.after_initialize - persisting registered roles!
+DEPRECATION WARNING: Hyrax::DerivativeService.services= is deprecated; favor Hyrax.config.derivative_servies=. (called from services= at /usr/local/bundle/bundler/gems/hyrax-c2b18e57523a/app/services/hyrax/derivative_service.rb:16)
+W, [2026-08-26T16:33:34.251529 #59957]  WARN -- : Scoped order is ignored, it's forced to be batch order.
+W, [2026-08-26T16:33:35.537460 #59957]  WARN -- : Fedora URL (http://127.0.0.1:99999/nil_fcrepo_endpoint) does not end with /rest. This could be a problem. Check your fedora.yml config
+=== (none) - 17 tenant(s) ===
+  profiles in use: ["DEFAULT"]
+  samvera                works=["GenericWork", "Image"]                       
+  kevin-demo             works=["GenericWork", "Image", "MobiusWork"]         exceeds=["MobiusWork"] orphaned=["MobiusWork"]
+  bridgewater-demo       works=["GenericWork", "Image"]                       
+  demo                   works=["Etd", "GenericWork", "Image", "MobiusWork", "Oer", "ScholarlyWork"] exceeds=["MobiusWork", "ScholarlyWork"] orphaned=["MobiusWork", "ScholarlyWork"]
+  mobius-search          works=["GenericWork", "Image", "MobiusWork"]         exceeds=["MobiusWork"] no_schema
+  alaska                 works=["GenericWork", "Image"]                       
+  dcpl-demo              works=["GenericWork", "Image"]                       
+  scientist-demo         works=["GenericWork", "Image"]                       
+  texas-state            works=["Etd", "GenericWork", "Image", "MobiusWork", "Oer", "ScholarlyWork"] exceeds=["MobiusWork", "ScholarlyWork"] orphaned=["MobiusWork", "ScholarlyWork"]
+  surfboard-archive      works=["Etd", "GenericWork", "Image", "MobiusWork", "Oer"] exceeds=["MobiusWork"] orphaned=["MobiusWork"]
+  main                   works=["Etd", "GenericWork", "Image", "MobiusWork", "Oer"] exceeds=["MobiusWork"] orphaned=["MobiusWork"]
+  wcs-demo               works=["Etd", "GenericWork", "Image", "MobiusWork", "Oer", "ScholarlyWork"] exceeds=["MobiusWork", "ScholarlyWork"] orphaned=["MobiusWork", "ScholarlyWork"]
+  qa                     works=["Etd", "GenericWork", "Image", "MobiusWork", "Oer", "ScholarlyWork"] exceeds=["MobiusWork", "ScholarlyWork"] orphaned=["MobiusWork", "ScholarlyWork"]
+  uw-cc                  works=["Etd", "GenericWork", "Image", "Oer"]         
+  flyovercountry         works=["Etd", "GenericWork", "Image", "MobiusWork", "Oer", "ScholarlyWork"] exceeds=["MobiusWork", "ScholarlyWork"] orphaned=["MobiusWork", "ScholarlyWork"]
+  new                    works=["Etd", "GenericWork", "Image", "Oer"]         
+  max-anon-test          works=["Etd", "GenericWork", "Image", "Oer"]         
+=== mobius - 17 tenant(s) ===
+  profiles in use: ["mobius/m3_profile.yaml"]
+  covenant               works=["MobiusWork"]                                 
+  crowder                works=["MobiusWork"]                                 
+  mbts                   works=["GenericWork", "Image", "MobiusWork"]         
+  mssu                   works=["MobiusWork"]                                 
+  nwmsu                  works=["MobiusWork"]                                 
+  stlcc                  works=["MobiusWork"]                                 
+  truman                 works=["MobiusWork"]                                 
+  webster                works=["MobiusWork"]                                 
+  ccis                   works=["GenericWork", "Image", "MobiusWork"]         
+  mobap                  works=["GenericWork", "Image", "MobiusWork"]         
+  sbuniv                 works=["GenericWork", "Image", "MobiusWork"]         
+  moval                  works=["GenericWork", "Image", "MobiusWork"]         
+  eastcentral            works=["GenericWork", "Image", "MobiusWork"]         
+  kenrick                works=["GenericWork", "Image", "MobiusWork"]         
+  jewell                 works=["GenericWork", "Image", "MobiusWork"]         
+  atsu                   works=["GenericWork", "Image", "MobiusWork"]         
+  stephens               works=["MobiusWork"]                                 
+=== stjude - 1 tenant(s) ===
+  profiles in use: ["stjude/m3_profile.yaml"]
+  stjude                 works=["Etd", "GenericWork", "Image", "MobiusWork", "Oer", "ScholarlyWork"] exceeds=["MobiusWork", "ScholarlyWork"] orphaned=["MobiusWork", "Oer", "ScholarlyWork"]
+=== unca - 2 tenant(s) ===
+  profiles in use: ["unca/m3_profile.yaml"]
+  wcu                    works=["Etd", "GenericWork", "Image", "Oer", "ScholarlyWork"] 
+  unca                   works=["Etd", "GenericWork", "Image", "Oer", "ScholarlyWork"] 
+
+=== PROBLEMS (9) ===
+  FAIL kevin-demo offers ["MobiusWork"] with no class in its profile
+  FAIL demo offers ["MobiusWork", "ScholarlyWork"] with no class in its profile
+  FAIL stjude offers ["Oer", "MobiusWork", "ScholarlyWork"] with no class in its profile
+  FAIL texas-state offers ["MobiusWork", "ScholarlyWork"] with no class in its profile
+  FAIL surfboard-archive offers ["MobiusWork"] with no class in its profile
+  FAIL main offers ["MobiusWork"] with no class in its profile
+  FAIL wcs-demo offers ["MobiusWork", "ScholarlyWork"] with no class in its profile
+  FAIL qa offers ["MobiusWork", "ScholarlyWork"] with no class in its profile
+  FAIL flyovercountry offers ["MobiusWork", "ScholarlyWork"] with no class in its profile
+command terminated with exit code 1

--- a/bin/deploy-check/baselines/production-2026-08-26-derivatives.txt
+++ b/bin/deploy-check/baselines/production-2026-08-26-derivatives.txt
@@ -1,0 +1,51 @@
+I, [2026-08-26T22:38:54.743430 #29981]  INFO -- : ActiveFedora: loading fedora config from /app/samvera/hyrax-webapp/config/fedora.yml
+I, [2026-08-26T22:38:54.744898 #29981]  INFO -- : ActiveFedora: loading solr config from /app/samvera/hyrax-webapp/config/solr.yml
+W, [2026-08-26T22:38:55.612233 #29981]  WARN -- : Same predicate (http://purl.org/dc/terms/accessRights) used for properties additional_information and access_right
+W, [2026-08-26T22:38:55.615586 #29981]  WARN -- : Same predicate (http://purl.org/dc/terms/bibliographicCitation) used for properties bibliographic_citation and bibliographic_citation
+W, [2026-08-26T22:38:55.645369 #29981]  WARN -- : Same predicate (http://purl.org/dc/terms/accessRights) used for properties additional_information and access_right
+W, [2026-08-26T22:38:55.648904 #29981]  WARN -- : Same predicate (http://purl.org/dc/terms/bibliographicCitation) used for properties bibliographic_citation and bibliographic_citation
+I, [2026-08-26T22:39:07.484319 #29981]  INFO -- : Hyrax::Engine.after_initialize - persisting registered roles!
+W, [2026-08-26T22:39:10.801245 #29981]  WARN -- : Scoped order is ignored, it's forced to be batch order.
+W, [2026-08-26T22:39:13.773003 #29981]  WARN -- : Fedora URL (http://127.0.0.1:99999/nil_fcrepo_endpoint) does not end with /rest. This could be a problem. Check your fedora.yml config
+=== A/V derivative playability ===
+  mp3:present            103
+  mp4:missing            2
+  mp4:moov_last          51
+  ogg:present            103
+  thumbnail:missing      2
+  thumbnail:present      51
+
+=== PROBLEMS (55) ===
+  FAIL samvera video fe4302a2-7667-47a7-8822-93fa6bf400f7 mp4: moov_last
+  FAIL samvera video ad3c52da-5fe7-400f-8432-dec07a5b8760 mp4: moov_last
+  FAIL samvera video 9d730a31-481b-44ea-8fd5-6efd187df09e mp4: moov_last
+  FAIL samvera video 5811e661-e481-4cd4-8c8d-112d581c9554 mp4: moov_last
+  FAIL samvera video 5f65c55f-6b4e-4366-8b97-c2d6d7a70f19 mp4: moov_last
+  FAIL samvera video 79abac81-8049-4f8c-bb89-cc345e5e0703 mp4: moov_last
+  FAIL samvera video aa41b809-12fe-4f41-bc87-7bd22ff145e2 mp4: moov_last
+  FAIL samvera video 387e4b5a-976b-4166-be38-b35fdd94c066 mp4: moov_last
+  FAIL samvera video adf8a0a2-d850-4244-bacc-72c0e45d0a0a mp4: moov_last
+  FAIL samvera video 2930c1e0-e088-47da-a32e-a1a0f2e8a399 mp4: moov_last
+  FAIL samvera video bda2a853-51f3-4ee7-acff-c64e41c26657 mp4: moov_last
+  FAIL kevin-demo video 8e5ef3c1-405f-47b6-a16c-f12e4f225b66 mp4: moov_last
+  FAIL kevin-demo video 11b3ca46-bcd9-4a8a-bbf5-1635ab71b488 mp4: moov_last
+  FAIL covenant video 8e5ef3c1-405f-47b6-a16c-f12e4f225b66 mp4: moov_last
+  FAIL crowder video 259590bb-6f99-4328-bb12-d1cf3bc2d556 mp4: moov_last
+  FAIL crowder video 34b67a6c-45a2-4b05-a22f-82bf75fedf85 mp4: moov_last
+  FAIL crowder video 51f4ac35-1cd8-4d43-9900-e753803d4c1a mp4: moov_last
+  FAIL crowder video 7ac20df3-03a1-4390-b0dd-f3d040bb4c7a mp4: moov_last
+  FAIL crowder video a73b7532-de24-4471-8140-bf7255f0cf3b mp4: moov_last
+  FAIL crowder video e35a50e9-71a1-42be-bcf6-f88b16eb3318 thumbnail: missing
+  FAIL crowder video e35a50e9-71a1-42be-bcf6-f88b16eb3318 mp4: missing
+  FAIL crowder video 8ad599e1-e896-4d2d-882c-7df7b23499b8 mp4: moov_last
+  FAIL crowder video 9e4ee7a8-472d-49c3-aa1a-0b10411e4eae mp4: moov_last
+  FAIL crowder video fbaf37ab-f670-428f-8571-ce991d007195 mp4: moov_last
+  FAIL nwmsu video 8e5ef3c1-405f-47b6-a16c-f12e4f225b66 mp4: moov_last
+  FAIL stlcc video af53e089-57c0-432e-bf21-c89ae92c7556 mp4: moov_last
+  FAIL moval video 8e5ef3c1-405f-47b6-a16c-f12e4f225b66 mp4: moov_last
+  FAIL kenrick video 8e5ef3c1-405f-47b6-a16c-f12e4f225b66 mp4: moov_last
+  FAIL jewell video bd39e549-58bb-4fb3-a634-47ceefb9a133 mp4: moov_last
+  FAIL demo video 8e5ef3c1-405f-47b6-a16c-f12e4f225b66 mp4: moov_last
+  ...and 25 more
+
+moov_last means Safari cannot start playback while Chrome can. Fix upstream with `-movflags +faststart` on the mp4 derivative encode, then regenerate.

--- a/bin/deploy-check/baselines/production-2026-08-26-post-v1.1.0-consortium.txt
+++ b/bin/deploy-check/baselines/production-2026-08-26-post-v1.1.0-consortium.txt
@@ -1,4 +1,4 @@
-Defaulted container "hyrax" out of: hyrax, load-solr-config (init), db-setup (init), sync-static-assets (init)
+Defaulted container "hyrax" out of: hyrax, load-solr-config (init), db-setup (init)
 /usr/local/bundle/gems/bundler-2.6.9/lib/bundler/rubygems_ext.rb:64: warning: already initialized constant Gem::Platform::JAVA
 /usr/local/lib/ruby/site_ruby/3.3.0/rubygems/platform.rb:279: warning: previous definition of JAVA was here
 /usr/local/bundle/gems/bundler-2.6.9/lib/bundler/rubygems_ext.rb:65: warning: already initialized constant Gem::Platform::MSWIN
@@ -18,19 +18,19 @@ Defaulted container "hyrax" out of: hyrax, load-solr-config (init), db-setup (in
 /usr/local/bundle/gems/bundler-2.6.9/lib/bundler/rubygems_ext.rb:73: warning: already initialized constant Gem::Platform::X64_LINUX_MUSL
 /usr/local/lib/ruby/site_ruby/3.3.0/rubygems/platform.rb:288: warning: previous definition of X64_LINUX_MUSL was here
 [DEPRECATION] PCDM is deprecating 'Valkyrie::Vocab::PCDMUse#PreservationMasterFile'. Use 'Valkyrie::Vocab::PCDMUse#PreservationFile' instead. This warning does *not* indicate that usage of the deprecated term has been detected.
-DEPRECATION WARNING: You are using deprecated behavior which will be removed from the next major or minor release. (called from block (2 levels) in <class:Engine> at /usr/local/bundle/gems/iiif_print-3.0.12/lib/iiif_print/engine.rb:67)
+DEPRECATION WARNING: You are using deprecated behavior which will be removed from the next major or minor release. (called from block (2 levels) in <class:Engine> at /usr/local/bundle/gems/iiif_print-3.1.0/lib/iiif_print/engine.rb:67)
 /app/samvera/config/initializers/hyrax.rb:7: warning: already initialized constant HykuKnapsack::DEFAULT_M3_PROFILE_PATH
 /app/samvera/config/initializers/hyrax.rb:7: warning: previous definition of DEFAULT_M3_PROFILE_PATH was here
 /app/samvera/config/initializers/knapsack_authorities.rb:12: warning: already initialized constant HykuKnapsack::AUTHORITIES_PATH
 /app/samvera/config/initializers/knapsack_authorities.rb:12: warning: previous definition of AUTHORITIES_PATH was here
-DEPRECATION WARNING: ActiveFedora and Wings will be removed from a future major release of Hyrax in favor of Valkyrie resource models. Please migrate your models from ActiveFedora::Base to Hyrax::Resource. (called from <module:Wings> at /usr/local/bundle/bundler/gems/hyrax-c2b18e57523a/lib/wings.rb:64)
-I, [2026-08-26T16:33:19.068462 #59957]  INFO -- : ActiveFedora: loading fedora config from /app/samvera/hyrax-webapp/config/fedora.yml
-I, [2026-08-26T16:33:19.069608 #59957]  INFO -- : ActiveFedora: loading solr config from /app/samvera/hyrax-webapp/config/solr.yml
-DEPRECATION WARNING: Hyrax::DerivativeService.services is deprecated; favor Hyrax.config.derivative_servies. (called from services at /usr/local/bundle/bundler/gems/hyrax-c2b18e57523a/app/services/hyrax/derivative_service.rb:22)
-W, [2026-08-26T16:33:19.922770 #59957]  WARN -- : Same predicate (http://purl.org/dc/terms/accessRights) used for properties additional_information and access_right
-W, [2026-08-26T16:33:19.927856 #59957]  WARN -- : Same predicate (http://purl.org/dc/terms/bibliographicCitation) used for properties bibliographic_citation and bibliographic_citation
-W, [2026-08-26T16:33:19.959572 #59957]  WARN -- : Same predicate (http://purl.org/dc/terms/accessRights) used for properties additional_information and access_right
-W, [2026-08-26T16:33:19.963514 #59957]  WARN -- : Same predicate (http://purl.org/dc/terms/bibliographicCitation) used for properties bibliographic_citation and bibliographic_citation
+DEPRECATION WARNING: ActiveFedora and Wings will be removed from a future major release of Hyrax in favor of Valkyrie resource models. Please migrate your models from ActiveFedora::Base to Hyrax::Resource. (called from <module:Wings> at /usr/local/bundle/bundler/gems/hyrax-4bd778e968d1/lib/wings.rb:64)
+I, [2026-08-26T20:19:05.530854 #1410]  INFO -- : ActiveFedora: loading fedora config from /app/samvera/hyrax-webapp/config/fedora.yml
+I, [2026-08-26T20:19:05.531893 #1410]  INFO -- : ActiveFedora: loading solr config from /app/samvera/hyrax-webapp/config/solr.yml
+DEPRECATION WARNING: Hyrax::DerivativeService.services is deprecated; favor Hyrax.config.derivative_servies. (called from services at /usr/local/bundle/bundler/gems/hyrax-4bd778e968d1/app/services/hyrax/derivative_service.rb:22)
+W, [2026-08-26T20:19:06.248486 #1410]  WARN -- : Same predicate (http://purl.org/dc/terms/accessRights) used for properties additional_information and access_right
+W, [2026-08-26T20:19:06.251579 #1410]  WARN -- : Same predicate (http://purl.org/dc/terms/bibliographicCitation) used for properties bibliographic_citation and bibliographic_citation
+W, [2026-08-26T20:19:06.283240 #1410]  WARN -- : Same predicate (http://purl.org/dc/terms/accessRights) used for properties additional_information and access_right
+W, [2026-08-26T20:19:06.286313 #1410]  WARN -- : Same predicate (http://purl.org/dc/terms/bibliographicCitation) used for properties bibliographic_citation and bibliographic_citation
 DEPRECATION WARNING: Blacklight::Base is deprecated and will be removed in Blacklight 8.0.0.
 	Include Blacklight::Configurable and Blacklight::SearchContext as needed (included in Blacklight::Catalog). (called from included at /usr/local/bundle/gems/blacklight-7.41.0/app/controllers/concerns/blacklight/base.rb:9)
 DEPRECATION WARNING: Blacklight::Base is deprecated and will be removed in Blacklight 8.0.0.
@@ -39,18 +39,16 @@ DEPRECATION WARNING: Blacklight::AccessControls::Enforcement is deprecated and w
 DEPRECATION WARNING: Blacklight::Base is deprecated and will be removed in Blacklight 8.0.0.
 	Include Blacklight::Configurable and Blacklight::SearchContext as needed (included in Hyrax::MyController). (called from included at /usr/local/bundle/gems/blacklight-7.41.0/app/controllers/concerns/blacklight/base.rb:9)
 /app/samvera/hyrax-webapp/app/services/hyrax/collection_types/create_service_decorator.rb:151: warning: already initialized constant Hyrax::CollectionTypes::CreateService::DEFAULT_OPTIONS
-/usr/local/bundle/bundler/gems/hyrax-c2b18e57523a/app/services/hyrax/collection_types/create_service.rb:15: warning: previous definition of DEFAULT_OPTIONS was here
+/usr/local/bundle/bundler/gems/hyrax-4bd778e968d1/app/services/hyrax/collection_types/create_service.rb:15: warning: previous definition of DEFAULT_OPTIONS was here
 /app/samvera/hyrax-webapp/app/services/hyrax/collection_types/create_service_decorator.rb:152: warning: already initialized constant Hyrax::CollectionTypes::CreateService::USER_COLLECTION_OPTIONS
-/usr/local/bundle/bundler/gems/hyrax-c2b18e57523a/app/services/hyrax/collection_types/create_service.rb:33: warning: previous definition of USER_COLLECTION_OPTIONS was here
-/usr/local/bundle/bundler/gems/hyrax-c2b18e57523a/app/services/hyrax/user_stat_importer.rb:6: warning: redefining constant Struct::UserRecord
-DEPRECATION WARNING: Hyrax::DerivativeService.services= is deprecated; favor Hyrax.config.derivative_servies=. (called from services= at /usr/local/bundle/bundler/gems/hyrax-c2b18e57523a/app/services/hyrax/derivative_service.rb:16)
-DEPRECATION WARNING: Blacklight::Base is deprecated and will be removed in Blacklight 8.0.0.
-	Include Blacklight::Configurable and Blacklight::SearchContext as needed (included in Hyrax::IiifAv::IiifAvController). (called from included at /usr/local/bundle/gems/blacklight-7.41.0/app/controllers/concerns/blacklight/base.rb:9)
+/usr/local/bundle/bundler/gems/hyrax-4bd778e968d1/app/services/hyrax/collection_types/create_service.rb:33: warning: previous definition of USER_COLLECTION_OPTIONS was here
+/usr/local/bundle/bundler/gems/hyrax-4bd778e968d1/app/services/hyrax/user_stat_importer.rb:6: warning: redefining constant Struct::UserRecord
+DEPRECATION WARNING: Hyrax::DerivativeService.services= is deprecated; favor Hyrax.config.derivative_servies=. (called from services= at /usr/local/bundle/bundler/gems/hyrax-4bd778e968d1/app/services/hyrax/derivative_service.rb:16)
 DEPRECATION WARNING: Blacklight::AccessControls::Enforcement is deprecated and will be removed in 1.0. (called from block in <module:Enforcement> at /usr/local/bundle/gems/blacklight-access_controls-6.1.0/lib/blacklight/access_controls/enforcement.rb:23)
-I, [2026-08-26T16:33:31.345143 #59957]  INFO -- : Hyrax::Engine.after_initialize - persisting registered roles!
-DEPRECATION WARNING: Hyrax::DerivativeService.services= is deprecated; favor Hyrax.config.derivative_servies=. (called from services= at /usr/local/bundle/bundler/gems/hyrax-c2b18e57523a/app/services/hyrax/derivative_service.rb:16)
-W, [2026-08-26T16:33:34.251529 #59957]  WARN -- : Scoped order is ignored, it's forced to be batch order.
-W, [2026-08-26T16:33:35.537460 #59957]  WARN -- : Fedora URL (http://127.0.0.1:99999/nil_fcrepo_endpoint) does not end with /rest. This could be a problem. Check your fedora.yml config
+I, [2026-08-26T20:19:17.080195 #1410]  INFO -- : Hyrax::Engine.after_initialize - persisting registered roles!
+DEPRECATION WARNING: Hyrax::DerivativeService.services= is deprecated; favor Hyrax.config.derivative_servies=. (called from services= at /usr/local/bundle/bundler/gems/hyrax-4bd778e968d1/app/services/hyrax/derivative_service.rb:16)
+W, [2026-08-26T20:19:20.050871 #1410]  WARN -- : Scoped order is ignored, it's forced to be batch order.
+W, [2026-08-26T20:19:20.995677 #1410]  WARN -- : Fedora URL (http://127.0.0.1:99999/nil_fcrepo_endpoint) does not end with /rest. This could be a problem. Check your fedora.yml config
 === (none) - 17 tenant(s) ===
   profiles in use: ["DEFAULT"]
   samvera                works=["GenericWork", "Image"]                       

--- a/bin/deploy-check/baselines/production-2026-08-26-post-v1.1.0.json
+++ b/bin/deploy-check/baselines/production-2026-08-26-post-v1.1.0.json
@@ -9,17 +9,36 @@
       "Oer",
       "ScholarlyWork"
     ],
-    "realtime_notifications": false,
+    "realtime_notifications": true,
     "iiif_av_viewer": "universal_viewer",
-    "iiif_manifest_factory": "IIIFManifest::ManifestFactory",
-    "derivative_labels": "ERROR: NoMethodError: undefined method `derivative_options' for an instance of Hyrax::Configuration",
+    "iiif_manifest_factory": "IIIFManifest::V3::ManifestFactory",
+    "derivative_labels": {
+      "pdf": [
+        "thumbnail"
+      ],
+      "office": [
+        "",
+        "thumbnail"
+      ],
+      "audio": [
+        "mp3",
+        "ogg"
+      ],
+      "video": [
+        "mp4",
+        "thumbnail"
+      ],
+      "image": [
+        "thumbnail"
+      ]
+    },
     "consortia_defined": [
       "mobius",
       "stjude",
       "unca"
     ],
-    "puma_version": "5.6.9",
-    "hyrax_version": "5.2.0"
+    "puma_version": "7.2.1",
+    "hyrax_version": "5.3.0"
   },
   "tenants": {
     "samvera": {
@@ -50,7 +69,18 @@
         "OerResource"
       ],
       "schema_version": "2",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 16613,
         "filesets": 0,
@@ -58,7 +88,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": true,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -77,7 +107,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -85,7 +114,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -135,7 +167,18 @@
         "OerResource"
       ],
       "schema_version": "2",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 995,
         "filesets": 0,
@@ -143,7 +186,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -162,7 +205,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": false,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -170,7 +212,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -219,7 +264,18 @@
         "OerResource"
       ],
       "schema_version": "1",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 96,
         "filesets": 0,
@@ -227,7 +283,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -246,7 +302,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": false,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -254,7 +309,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": false,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -304,7 +362,18 @@
         "OerResource"
       ],
       "schema_version": "4",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 1421,
         "filesets": 0,
@@ -312,7 +381,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -331,7 +400,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": false,
-        "show_share_button": false,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -339,7 +407,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": false,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -389,7 +460,18 @@
         "OerResource"
       ],
       "schema_version": "7",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 1085,
         "filesets": 0,
@@ -397,7 +479,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -416,7 +498,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -424,7 +505,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -476,7 +560,18 @@
         "OerResource"
       ],
       "schema_version": "3",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 5901,
         "filesets": 0,
@@ -484,7 +579,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -503,7 +598,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -511,7 +605,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -561,7 +658,18 @@
         "OerResource"
       ],
       "schema_version": "3",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 12810,
         "filesets": 0,
@@ -569,7 +677,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -588,7 +696,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": false,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -596,7 +703,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": false,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -646,7 +756,18 @@
         "OerResource"
       ],
       "schema_version": "4",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 1188,
         "filesets": 0,
@@ -654,7 +775,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -673,7 +794,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": true,
         "show_featured_researcher": false,
-        "show_share_button": false,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -681,7 +801,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": false,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -731,7 +854,18 @@
         "OerResource"
       ],
       "schema_version": "3",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 492,
         "filesets": 0,
@@ -739,7 +873,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -758,7 +892,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -766,7 +899,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -816,7 +952,18 @@
         "OerResource"
       ],
       "schema_version": "8",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 36234,
         "filesets": 0,
@@ -824,7 +971,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": true,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": true,
         "hide_social_buttons": false,
@@ -843,7 +990,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": false,
-        "show_share_button": false,
         "show_featured_works": true,
         "show_recently_uploaded": false,
         "show_identity_provider_in_admin_dashboard": false,
@@ -851,7 +997,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": false,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -901,7 +1050,18 @@
         "OerResource"
       ],
       "schema_version": "3",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 1102,
         "filesets": 0,
@@ -909,7 +1069,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": true,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": true,
         "hide_social_buttons": false,
@@ -928,7 +1088,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": true,
         "show_featured_researcher": false,
-        "show_share_button": false,
         "show_featured_works": true,
         "show_recently_uploaded": false,
         "show_identity_provider_in_admin_dashboard": false,
@@ -936,7 +1095,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": true
+        "include_guided_import": true,
+        "show_share_button": false,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -988,7 +1150,18 @@
         "OerResource"
       ],
       "schema_version": "3",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 3253,
         "filesets": 0,
@@ -996,7 +1169,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": true,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -1015,7 +1188,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": false,
-        "show_share_button": false,
         "show_featured_works": true,
         "show_recently_uploaded": false,
         "show_identity_provider_in_admin_dashboard": false,
@@ -1023,7 +1195,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": false,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -1075,7 +1250,18 @@
         "OerResource"
       ],
       "schema_version": "3",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 179,
         "filesets": 0,
@@ -1083,7 +1269,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -1102,7 +1288,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -1110,7 +1295,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -1162,7 +1350,18 @@
         "OerResource"
       ],
       "schema_version": "3",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 1658,
         "filesets": 0,
@@ -1170,7 +1369,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -1189,7 +1388,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -1197,7 +1395,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -1249,7 +1450,18 @@
         "OerResource"
       ],
       "schema_version": "3",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 482,
         "filesets": 0,
@@ -1257,7 +1469,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -1276,7 +1488,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -1284,7 +1495,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -1336,7 +1550,18 @@
         "OerResource"
       ],
       "schema_version": "3",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 5,
         "filesets": 0,
@@ -1344,7 +1569,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -1363,7 +1588,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -1371,7 +1595,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [],
       "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
@@ -1407,7 +1634,18 @@
         "OerResource"
       ],
       "schema_version": "3",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 26,
         "filesets": 0,
@@ -1415,7 +1653,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -1434,7 +1672,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -1442,7 +1679,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -1494,7 +1734,18 @@
         "OerResource"
       ],
       "schema_version": "3",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 1944,
         "filesets": 0,
@@ -1502,7 +1753,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -1521,7 +1772,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -1529,7 +1779,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -1582,7 +1835,18 @@
         "OerResource"
       ],
       "schema_version": "4",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 559,
         "filesets": 0,
@@ -1609,7 +1873,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": true,
@@ -1617,7 +1880,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": true,
-        "include_guided_import": true
+        "include_guided_import": true,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -1669,7 +1935,18 @@
         "OerResource"
       ],
       "schema_version": "5",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 17,
         "filesets": 0,
@@ -1677,7 +1954,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -1696,7 +1973,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -1704,7 +1980,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -1754,7 +2033,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": true,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -1773,7 +2052,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -1781,7 +2059,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -1830,7 +2111,18 @@
         "OerResource"
       ],
       "schema_version": "1",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 5,
         "filesets": 0,
@@ -1838,7 +2130,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -1857,7 +2149,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": false,
-        "show_share_button": false,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -1865,7 +2156,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": false,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [],
       "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
@@ -1898,7 +2192,18 @@
         "OerResource"
       ],
       "schema_version": "2",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 5,
         "filesets": 0,
@@ -1906,7 +2211,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -1925,7 +2230,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -1933,7 +2237,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [],
       "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
@@ -1966,7 +2273,18 @@
         "OerResource"
       ],
       "schema_version": "1",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 5,
         "filesets": 0,
@@ -1974,7 +2292,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -1993,7 +2311,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -2001,7 +2318,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [],
       "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
@@ -2039,7 +2359,18 @@
         "ScholarlyWork"
       ],
       "schema_version": "4",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 4746,
         "filesets": 0,
@@ -2047,7 +2378,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -2066,7 +2397,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": false,
-        "show_share_button": false,
         "show_featured_works": false,
         "show_recently_uploaded": false,
         "show_identity_provider_in_admin_dashboard": true,
@@ -2074,7 +2404,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": true
+        "include_guided_import": true,
+        "show_share_button": false,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -2128,7 +2461,18 @@
         "ScholarlyWork"
       ],
       "schema_version": "3",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 3,
         "filesets": 0,
@@ -2136,7 +2480,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -2155,7 +2499,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": true,
@@ -2163,7 +2506,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [],
       "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
@@ -2197,7 +2543,18 @@
         "OerResource"
       ],
       "schema_version": "5",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 245,
         "filesets": 0,
@@ -2205,7 +2562,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -2224,7 +2581,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": false,
-        "show_share_button": false,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -2232,7 +2588,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": false,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -2285,7 +2644,17 @@
       ],
       "schema_version": "14",
       "vocabularies": {
-        "mesh": 30954
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "mesh": 30954,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
       },
       "counts": {
         "works": 252,
@@ -2294,7 +2663,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -2313,7 +2682,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": false,
-        "show_share_button": true,
         "show_featured_works": false,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": true,
@@ -2321,7 +2689,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -2374,7 +2745,18 @@
         "OerResource"
       ],
       "schema_version": "1",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 1,
         "filesets": 0,
@@ -2382,7 +2764,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -2401,7 +2783,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -2409,7 +2790,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [],
       "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
@@ -2445,7 +2829,18 @@
         "OerResource"
       ],
       "schema_version": "1",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 1,
         "filesets": 0,
@@ -2453,7 +2848,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -2472,7 +2867,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -2480,7 +2874,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [],
       "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
@@ -2516,7 +2913,18 @@
         "OerResource"
       ],
       "schema_version": "2",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 1,
         "filesets": 0,
@@ -2524,7 +2932,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": true,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -2543,7 +2951,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -2551,7 +2958,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [],
       "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
@@ -2588,7 +2998,18 @@
         "OerResource"
       ],
       "schema_version": "2",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 56,
         "filesets": 0,
@@ -2596,7 +3017,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -2615,7 +3036,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": false,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -2623,7 +3043,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": false,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -2676,7 +3099,18 @@
         "OerResource"
       ],
       "schema_version": "1",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 1,
         "filesets": 0,
@@ -2684,7 +3118,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -2703,7 +3137,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -2711,7 +3144,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [],
       "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
@@ -2746,7 +3182,18 @@
         "OerResource"
       ],
       "schema_version": "2",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 1,
         "filesets": 0,
@@ -2754,7 +3201,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -2773,7 +3220,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": false,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": true,
@@ -2781,7 +3227,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [],
       "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
@@ -2818,7 +3267,18 @@
         "OerResource"
       ],
       "schema_version": "1",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 8,
         "filesets": 0,
@@ -2826,7 +3286,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -2845,7 +3305,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -2853,7 +3312,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [
         {
@@ -2899,7 +3361,18 @@
         "OerResource"
       ],
       "schema_version": "1",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 1,
         "filesets": 0,
@@ -2907,7 +3380,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -2926,7 +3399,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -2934,7 +3406,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [],
       "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
@@ -2969,7 +3444,18 @@
         "OerResource"
       ],
       "schema_version": "1",
-      "vocabularies": {},
+      "vocabularies": {
+        "accessibility_features": 18,
+        "accessibility_hazards": 4,
+        "audience": 3,
+        "discipline": 65,
+        "education_levels": 5,
+        "learning_resource_types": 15,
+        "licenses": 15,
+        "oer_types": 12,
+        "resource_types": 20,
+        "rights_statements": 12
+      },
       "counts": {
         "works": 1,
         "filesets": 0,
@@ -2977,7 +3463,7 @@
       },
       "features": {
         "cache_work_iiif_manifest": false,
-        "iiif_av": false,
+        "iiif_av": true,
         "iiif_pdf": false,
         "hide_private_items": false,
         "hide_social_buttons": false,
@@ -2996,7 +3482,6 @@
         "home_page_recent_document_show_keyword": false,
         "show_workflow_roles_menu_item_in_admin_dashboard_sidebar": false,
         "show_featured_researcher": true,
-        "show_share_button": true,
         "show_featured_works": true,
         "show_recently_uploaded": true,
         "show_identity_provider_in_admin_dashboard": false,
@@ -3004,7 +3489,10 @@
         "show_login_link": true,
         "treat_some_user_inputs_as_markdown": false,
         "use_tenant_specific_colors": false,
-        "include_guided_import": false
+        "include_guided_import": false,
+        "show_share_button": true,
+        "enable_guided_deposit": false,
+        "enable_standard_deposit": true
       },
       "sample_works": [],
       "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"

--- a/bin/deploy-check/baselines/production-2026-08-26-post-v1.1.0.json
+++ b/bin/deploy-check/baselines/production-2026-08-26-post-v1.1.0.json
@@ -82,8 +82,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 16613,
-        "filesets": 0,
+        "works": 759,
+        "filesets": 813,
         "users": 138
       },
       "features": {
@@ -121,22 +121,22 @@
       },
       "sample_works": [
         {
-          "id": "d083760c-2e0c-43f5-a584-7dcb95f90390",
-          "model": "CollectionResource",
+          "id": "5c155a4a-0d1a-48fc-8b4f-5eef99975a0b",
+          "model": "ImageResource",
           "has_thumbnail": true
         },
         {
-          "id": "c4cda225-e32e-47ff-b775-51ed7e87431c",
-          "model": "CollectionResource",
+          "id": "1596dfa9-b436-4446-a7f2-f65cc702eefd",
+          "model": "ImageResource",
           "has_thumbnail": true
         },
         {
-          "id": "d4f44f37-1e91-499c-a803-f6b017a5d10a",
-          "model": "CollectionResource",
+          "id": "db829c0e-0cd8-4eef-b1dc-c64f7d829d91",
+          "model": "ImageResource",
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "kevin-demo": {
       "consortia": null,
@@ -180,8 +180,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 995,
-        "filesets": 0,
+        "works": 30,
+        "filesets": 202,
         "users": 138
       },
       "features": {
@@ -219,22 +219,22 @@
       },
       "sample_works": [
         {
-          "id": "87f8f787-9577-4015-ab19-fefea26637f3",
-          "model": "CollectionResource",
-          "has_thumbnail": true
-        },
-        {
           "id": "18118522-4970-475f-9f25-14723010ae91",
           "model": "GenericWorkResource",
           "has_thumbnail": true
         },
         {
-          "id": "757e18e8-8c82-42cd-bb7a-04cce60b932a",
-          "model": "Hyrax::FileSet",
+          "id": "822c7b84-8f06-46c6-92f3-33a5a4c2543f",
+          "model": "GenericWorkResource",
+          "has_thumbnail": true
+        },
+        {
+          "id": "3746188e-d78d-4894-b56d-c71ccda65772",
+          "model": "GenericWorkResource",
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "bridgewater-demo": {
       "consortia": null,
@@ -277,8 +277,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 96,
-        "filesets": 0,
+        "works": 4,
+        "filesets": 5,
         "users": 138
       },
       "features": {
@@ -316,22 +316,22 @@
       },
       "sample_works": [
         {
-          "id": "7f11bf91-84b3-4262-9aeb-c40cf0e9320c",
-          "model": "CollectionResource",
-          "has_thumbnail": true
-        },
-        {
           "id": "d95c26e0-0ca5-42a9-9d94-f315592d993b",
           "model": "ImageResource",
           "has_thumbnail": true
         },
         {
-          "id": "7518e598-b5c9-4aa2-b6a5-e5230499a1fd",
-          "model": "Hyrax::FileSet",
+          "id": "3a1b474f-d9ed-4261-8bc2-7bfa857b7549",
+          "model": "ImageResource",
+          "has_thumbnail": true
+        },
+        {
+          "id": "a3cc7301-c2e1-4aa9-8444-91b08d3cf97a",
+          "model": "ImageResource",
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "covenant": {
       "consortia": "mobius",
@@ -375,8 +375,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 1421,
-        "filesets": 0,
+        "works": 359,
+        "filesets": 392,
         "users": 138
       },
       "features": {
@@ -414,22 +414,22 @@
       },
       "sample_works": [
         {
-          "id": "8e5ef3c1-405f-47b6-a16c-f12e4f225b66",
-          "model": "Hyrax::FileSet",
+          "id": "3cd3048e-fde5-4617-8773-cd92edf65460",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "f903479b-bd90-44cc-b2cc-732b20f65b56",
-          "model": "Collection",
+          "id": "ca4d9a76-aa64-4390-bf5f-d4e5ca07f69e",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "760ee6e6-6cd7-4247-adbc-5642800e232d",
-          "model": "Collection",
+          "id": "40b64303-e0bc-41c8-b805-7a9d81f058dc",
+          "model": "MobiusWork",
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "crowder": {
       "consortia": "mobius",
@@ -473,8 +473,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 1085,
-        "filesets": 0,
+        "works": 353,
+        "filesets": 353,
         "users": 138
       },
       "features": {
@@ -512,22 +512,22 @@
       },
       "sample_works": [
         {
-          "id": "2e956c21-6f00-49f8-bedf-ee6f177d8352",
-          "model": "Collection",
+          "id": "6cabe75c-74ac-42a1-a38f-a0bf693ffb2c",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "35c8dfbc-eb55-4e5e-b364-b22593c17422",
-          "model": "Collection",
+          "id": "453381aa-de3e-48f4-9c44-0e6a8ca83232",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "c6fd3d11-8dad-4ef3-8ab1-ad0c082166e2",
-          "model": "Collection",
+          "id": "283790b6-fd46-4d71-b720-65ca9601c157",
+          "model": "MobiusWork",
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "mbts": {
       "consortia": "mobius",
@@ -573,8 +573,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 5901,
-        "filesets": 0,
+        "works": 1842,
+        "filesets": 1919,
         "users": 138
       },
       "features": {
@@ -612,22 +612,22 @@
       },
       "sample_works": [
         {
-          "id": "30b0898c-66a7-4e61-8ddc-e8d5ff7c741e",
-          "model": "Collection",
+          "id": "05e22be9-abaa-453c-b9f5-1e867cd8cfd0",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "4717e2ef-b7f2-47fd-87cf-c508a9dc59e8",
-          "model": "Collection",
+          "id": "17bfd3e7-b027-4ba5-8bfb-980d1afdbd49",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "3a5d0092-249c-4a62-bb5e-9704e7a073df",
-          "model": "Collection",
+          "id": "7411a8cf-2278-4280-a96e-f8c10b936e20",
+          "model": "MobiusWork",
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "mssu": {
       "consortia": "mobius",
@@ -671,8 +671,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 12810,
-        "filesets": 0,
+        "works": 4247,
+        "filesets": 4247,
         "users": 138
       },
       "features": {
@@ -710,11 +710,6 @@
       },
       "sample_works": [
         {
-          "id": "2a3c72be-83d8-4d83-9387-2d1f491754dd",
-          "model": "Collection",
-          "has_thumbnail": true
-        },
-        {
           "id": "63fe5c54-8a69-422f-9833-db32fb62fb58",
           "model": "MobiusWork",
           "has_thumbnail": true
@@ -723,9 +718,14 @@
           "id": "d3c56e31-e099-48d8-b98a-bf78a7f393e4",
           "model": "MobiusWork",
           "has_thumbnail": true
+        },
+        {
+          "id": "2a959f9b-4d40-4987-9a58-49a159f6da71",
+          "model": "MobiusWork",
+          "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "nwmsu": {
       "consortia": "mobius",
@@ -769,8 +769,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 1188,
-        "filesets": 0,
+        "works": 386,
+        "filesets": 390,
         "users": 138
       },
       "features": {
@@ -808,22 +808,22 @@
       },
       "sample_works": [
         {
-          "id": "8e5ef3c1-405f-47b6-a16c-f12e4f225b66",
-          "model": "Hyrax::FileSet",
+          "id": "be569499-a039-41ea-953b-4387dba0777b",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "1e71fcb9-14ff-44b7-9f5d-ee8492ae41bf",
-          "model": "Hyrax::FileSet",
+          "id": "1e50bf74-fa99-497c-bddc-bce13f599f07",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "9dcde5a5-2f5f-4d36-9b53-024d52b3b89b",
-          "model": "Collection",
+          "id": "f06cac98-c91d-4a2a-b7a0-232f54bb801d",
+          "model": "MobiusWork",
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "stlcc": {
       "consortia": "mobius",
@@ -867,8 +867,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 492,
-        "filesets": 0,
+        "works": 138,
+        "filesets": 147,
         "users": 138
       },
       "features": {
@@ -906,22 +906,22 @@
       },
       "sample_works": [
         {
-          "id": "7fb0c8de-48ed-4f23-9975-fc787c61d98e",
-          "model": "Collection",
+          "id": "d8c8c02e-20b2-462e-95d8-7c8ad36690f1",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "435e1f5e-bf28-4390-b1c7-88b50b992b6d",
-          "model": "Collection",
+          "id": "daf2bcff-ef4e-489a-bbc4-128d9fa187f2",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "b0fe0c68-f679-4629-b776-8b1b1699ac58",
-          "model": "Collection",
+          "id": "3b2e5a94-635b-4855-a95c-575cbf8508df",
+          "model": "MobiusWork",
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "truman": {
       "consortia": "mobius",
@@ -965,8 +965,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 36234,
-        "filesets": 0,
+        "works": 4610,
+        "filesets": 16111,
         "users": 138
       },
       "features": {
@@ -1004,22 +1004,22 @@
       },
       "sample_works": [
         {
-          "id": "e66a2d2d-6860-48c8-a41b-02f09ca54621",
-          "model": "Collection",
+          "id": "eff55b07-4772-4737-816c-e803bc334d6a",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "33c4d6e7-df04-4835-b075-febddfbe1d04",
-          "model": "Collection",
+          "id": "0ecb60eb-10af-4147-9ce1-2705322861a4",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "5b832161-eb09-4623-8601-a6bddec05abf",
-          "model": "Collection",
+          "id": "561ea84a-d2cf-45ec-adaa-03facf2a3d33",
+          "model": "MobiusWork",
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "webster": {
       "consortia": "mobius",
@@ -1063,8 +1063,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 1102,
-        "filesets": 0,
+        "works": 293,
+        "filesets": 396,
         "users": 138
       },
       "features": {
@@ -1102,22 +1102,22 @@
       },
       "sample_works": [
         {
-          "id": "1e71fcb9-14ff-44b7-9f5d-ee8492ae41bf",
-          "model": "Hyrax::FileSet",
+          "id": "b2671385-d556-46a6-9713-d3ee8e5e251d",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "3efbbefd-5863-4724-aa2d-59b79f6b446b",
-          "model": "Collection",
+          "id": "7c4f039a-b33e-4190-a424-2a311a068a5d",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "7f36d858-717b-4570-853d-e0bfb1db7d98",
-          "model": "Collection",
+          "id": "de843146-16d8-41a4-9e70-8ea4b4d806b5",
+          "model": "MobiusWork",
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "ccis": {
       "consortia": "mobius",
@@ -1163,8 +1163,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 3253,
-        "filesets": 0,
+        "works": 1048,
+        "filesets": 1086,
         "users": 138
       },
       "features": {
@@ -1202,22 +1202,22 @@
       },
       "sample_works": [
         {
-          "id": "515e2916-7884-49bb-aec7-dca39f269133",
-          "model": "Collection",
+          "id": "a99745a6-0a50-4684-bc95-6cf89c1d7a8e",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "282cdfbf-afd2-4905-a575-3c96077dd1f3",
-          "model": "Collection",
+          "id": "6bffa7db-6c03-48ea-89f7-85b6ef2d5b10",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "5d070038-266b-4986-ae4b-4ec7a8aa4168",
-          "model": "Collection",
+          "id": "6b749eb0-fd0b-43c0-b5ad-b9da78263697",
+          "model": "MobiusWork",
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "mobap": {
       "consortia": "mobius",
@@ -1263,8 +1263,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 179,
-        "filesets": 0,
+        "works": 58,
+        "filesets": 58,
         "users": 138
       },
       "features": {
@@ -1302,22 +1302,22 @@
       },
       "sample_works": [
         {
-          "id": "bc415f57-a343-44ad-8dae-62e31bedb4dd",
-          "model": "Collection",
+          "id": "01d0b9aa-19ee-466e-bd52-a3cd365927b0",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "1012d11f-c5d1-4447-afac-aab4c0aa4293",
-          "model": "Collection",
+          "id": "342ebe40-8654-4c09-b25d-750e3b91da3a",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "5e55c74f-19db-446f-9d65-b714af939521",
-          "model": "Collection",
+          "id": "aa67526e-0c6a-4ccb-ae64-976d2a3fc753",
+          "model": "MobiusWork",
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "sbuniv": {
       "consortia": "mobius",
@@ -1363,8 +1363,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 1658,
-        "filesets": 0,
+        "works": 420,
+        "filesets": 422,
         "users": 138
       },
       "features": {
@@ -1402,22 +1402,22 @@
       },
       "sample_works": [
         {
-          "id": "7782edc7-b0f3-4d8f-9f57-997a941ebcba",
-          "model": "Collection",
+          "id": "03e24b64-aafb-47af-8652-1b3c3a427d9a",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "bf931e7d-8ac0-405d-8f93-c27efdaa704d",
-          "model": "Collection",
+          "id": "bfc7c9cc-701f-462d-9d29-923957217eb9",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "5e487bc9-6932-4840-b557-8cd79137810a",
-          "model": "Collection",
+          "id": "36efd081-35b0-4df0-939d-ff445181f858",
+          "model": "MobiusWork",
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "moval": {
       "consortia": "mobius",
@@ -1463,8 +1463,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 482,
-        "filesets": 0,
+        "works": 147,
+        "filesets": 149,
         "users": 138
       },
       "features": {
@@ -1502,22 +1502,22 @@
       },
       "sample_works": [
         {
-          "id": "8e5ef3c1-405f-47b6-a16c-f12e4f225b66",
-          "model": "Hyrax::FileSet",
+          "id": "0e8489f4-ceb2-48e5-8b8a-92d1a9e5676a",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "1e71fcb9-14ff-44b7-9f5d-ee8492ae41bf",
-          "model": "Hyrax::FileSet",
+          "id": "e38e2271-07fd-49b8-b6c4-fc624674eff0",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "1c3553b7-7979-4856-a77a-0776985e256e",
-          "model": "Collection",
+          "id": "56d489da-4099-4a53-a8f2-16e286d49c6c",
+          "model": "MobiusWork",
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "eastcentral": {
       "consortia": "mobius",
@@ -1563,7 +1563,7 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 5,
+        "works": 0,
         "filesets": 0,
         "users": 138
       },
@@ -1601,7 +1601,7 @@
         "enable_standard_deposit": true
       },
       "sample_works": [],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "kenrick": {
       "consortia": "mobius",
@@ -1647,8 +1647,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 26,
-        "filesets": 0,
+        "works": 8,
+        "filesets": 5,
         "users": 138
       },
       "features": {
@@ -1686,11 +1686,6 @@
       },
       "sample_works": [
         {
-          "id": "8e5ef3c1-405f-47b6-a16c-f12e4f225b66",
-          "model": "Hyrax::FileSet",
-          "has_thumbnail": true
-        },
-        {
           "id": "de0037cf-d246-43a5-9fde-7b0940ebf448",
           "model": "GenericWork",
           "has_thumbnail": true
@@ -1699,9 +1694,14 @@
           "id": "5116b7ee-8dc6-4833-a35c-48cf41f683a9",
           "model": "GenericWork",
           "has_thumbnail": true
+        },
+        {
+          "id": "932032f0-a0df-43d5-b09b-ddeeddc307bb",
+          "model": "GenericWork",
+          "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "jewell": {
       "consortia": "mobius",
@@ -1747,8 +1747,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 1944,
-        "filesets": 0,
+        "works": 662,
+        "filesets": 584,
         "users": 138
       },
       "features": {
@@ -1786,22 +1786,22 @@
       },
       "sample_works": [
         {
-          "id": "1aff11d4-fc90-464e-b82a-41806e769f44",
-          "model": "Collection",
+          "id": "1c8c9f70-a440-451c-8c87-6ca8c417adaa",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "966d34b3-2274-4ae4-9f28-133399a8ad6d",
-          "model": "Collection",
+          "id": "48c71c74-9eef-4d90-972c-c61c9768ad21",
+          "model": "MobiusWork",
           "has_thumbnail": true
         },
         {
-          "id": "6e609430-55b7-4b66-8e00-09010a5ef486",
-          "model": "Collection",
+          "id": "7708f002-5fef-4d02-bf4c-aa7c28b3f99d",
+          "model": "MobiusWork",
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "demo": {
       "consortia": null,
@@ -1821,7 +1821,7 @@
       ],
       "profile_path": "DEFAULT",
       "themes": {
-        "home": "community",
+        "home": "heritage",
         "show": "scholarly_show",
         "search": "list_view"
       },
@@ -1848,8 +1848,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 559,
-        "filesets": 0,
+        "works": 43,
+        "filesets": 95,
         "users": 138
       },
       "features": {
@@ -1892,17 +1892,17 @@
           "has_thumbnail": true
         },
         {
-          "id": "e72c3515-05ad-43b5-a729-64f03913bc15",
-          "model": "Hyrax::FileSet",
+          "id": "39434064-e090-434a-900d-7bf58e333f25",
+          "model": "ImageResource",
           "has_thumbnail": true
         },
         {
-          "id": "39434064-e090-434a-900d-7bf58e333f25",
+          "id": "4dd1a19f-0ffc-47ff-a64e-6cc5e01f211b",
           "model": "ImageResource",
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "atsu": {
       "consortia": "mobius",
@@ -1948,8 +1948,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 17,
-        "filesets": 0,
+        "works": 4,
+        "filesets": 5,
         "users": 138
       },
       "features": {
@@ -1987,22 +1987,22 @@
       },
       "sample_works": [
         {
-          "id": "8e5ef3c1-405f-47b6-a16c-f12e4f225b66",
-          "model": "Hyrax::FileSet",
-          "has_thumbnail": true
-        },
-        {
-          "id": "1e71fcb9-14ff-44b7-9f5d-ee8492ae41bf",
-          "model": "Hyrax::FileSet",
-          "has_thumbnail": true
-        },
-        {
           "id": "358f1acd-c353-467d-9d9c-061953385331",
+          "model": "Image",
+          "has_thumbnail": true
+        },
+        {
+          "id": "e55c37c3-5f0d-4345-9f10-586b2d36feb2",
+          "model": "Image",
+          "has_thumbnail": true
+        },
+        {
+          "id": "fdc4b259-2f25-446c-9fa0-62f296046074",
           "model": "Image",
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "mobius-search": {
       "consortia": null,
@@ -2027,8 +2027,8 @@
       "schema_version": "",
       "vocabularies": {},
       "counts": {
-        "works": 67797,
-        "filesets": 0,
+        "works": 14575,
+        "filesets": 26264,
         "users": 138
       },
       "features": {
@@ -2066,22 +2066,22 @@
       },
       "sample_works": [
         {
-          "id": "8e5ef3c1-405f-47b6-a16c-f12e4f225b66",
-          "model": "Hyrax::FileSet",
-          "has_thumbnail": true
-        },
-        {
-          "id": "1e71fcb9-14ff-44b7-9f5d-ee8492ae41bf",
-          "model": "Hyrax::FileSet",
-          "has_thumbnail": true
-        },
-        {
           "id": "de0037cf-d246-43a5-9fde-7b0940ebf448",
           "model": "GenericWork",
           "has_thumbnail": true
+        },
+        {
+          "id": "5116b7ee-8dc6-4833-a35c-48cf41f683a9",
+          "model": "GenericWork",
+          "has_thumbnail": true
+        },
+        {
+          "id": "a99745a6-0a50-4684-bc95-6cf89c1d7a8e",
+          "model": "MobiusWork",
+          "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "alaska": {
       "consortia": null,
@@ -2124,7 +2124,7 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 5,
+        "works": 0,
         "filesets": 0,
         "users": 138
       },
@@ -2162,7 +2162,7 @@
         "enable_standard_deposit": true
       },
       "sample_works": [],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "dcpl-demo": {
       "consortia": null,
@@ -2205,7 +2205,7 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 5,
+        "works": 0,
         "filesets": 0,
         "users": 138
       },
@@ -2243,7 +2243,7 @@
         "enable_standard_deposit": true
       },
       "sample_works": [],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "scientist-demo": {
       "consortia": null,
@@ -2286,7 +2286,7 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 5,
+        "works": 0,
         "filesets": 0,
         "users": 138
       },
@@ -2324,7 +2324,7 @@
         "enable_standard_deposit": true
       },
       "sample_works": [],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "wcu": {
       "consortia": "unca",
@@ -2372,8 +2372,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 4746,
-        "filesets": 0,
+        "works": 1562,
+        "filesets": 1565,
         "users": 138
       },
       "features": {
@@ -2426,7 +2426,7 @@
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "unca": {
       "consortia": "unca",
@@ -2474,7 +2474,7 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 3,
+        "works": 0,
         "filesets": 0,
         "users": 138
       },
@@ -2512,7 +2512,7 @@
         "enable_standard_deposit": true
       },
       "sample_works": [],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "stephens": {
       "consortia": "mobius",
@@ -2556,8 +2556,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 245,
-        "filesets": 0,
+        "works": 76,
+        "filesets": 82,
         "users": 138
       },
       "features": {
@@ -2595,22 +2595,22 @@
       },
       "sample_works": [
         {
-          "id": "8fbcd678-7c55-41ea-990d-0ef2f6535f42",
-          "model": "Collection",
-          "has_thumbnail": true
-        },
-        {
-          "id": "6f5ca490-bd7f-4651-8f67-5eeb2970e7b7",
-          "model": "Collection",
-          "has_thumbnail": true
-        },
-        {
           "id": "a369be5a-30ea-49f4-8fef-e9aceea2b8a1",
+          "model": "MobiusWork",
+          "has_thumbnail": true
+        },
+        {
+          "id": "731a7950-9910-494e-93b8-d4ae22ab63f7",
+          "model": "MobiusWork",
+          "has_thumbnail": true
+        },
+        {
+          "id": "b282e4c6-6e98-40c3-8425-4f531b2ea4db",
           "model": "MobiusWork",
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "stjude": {
       "consortia": "stjude",
@@ -2657,8 +2657,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 252,
-        "filesets": 0,
+        "works": 62,
+        "filesets": 67,
         "users": 138
       },
       "features": {
@@ -2696,11 +2696,6 @@
       },
       "sample_works": [
         {
-          "id": "14d1cb07-f9c6-49dc-b574-745b7b2a76f9",
-          "model": "Collection",
-          "has_thumbnail": true
-        },
-        {
           "id": "44ab2d55-7a93-4f8f-9c2f-afdab30867e6",
           "model": "GenericWork",
           "has_thumbnail": true
@@ -2709,9 +2704,14 @@
           "id": "df9766d1-f991-48b0-9a81-56328a27a9a2",
           "model": "GenericWork",
           "has_thumbnail": true
+        },
+        {
+          "id": "896ca639-6caf-45f4-8c2a-93704fa28ecd",
+          "model": "GenericWork",
+          "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "texas-state": {
       "consortia": null,
@@ -2758,7 +2758,7 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 1,
+        "works": 0,
         "filesets": 0,
         "users": 138
       },
@@ -2796,7 +2796,7 @@
         "enable_standard_deposit": true
       },
       "sample_works": [],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "surfboard-archive": {
       "consortia": null,
@@ -2842,7 +2842,7 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 1,
+        "works": 0,
         "filesets": 0,
         "users": 138
       },
@@ -2880,7 +2880,7 @@
         "enable_standard_deposit": true
       },
       "sample_works": [],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "main": {
       "consortia": null,
@@ -2926,7 +2926,7 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 1,
+        "works": 0,
         "filesets": 0,
         "users": 138
       },
@@ -2964,7 +2964,7 @@
         "enable_standard_deposit": true
       },
       "sample_works": [],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "wcs-demo": {
       "consortia": null,
@@ -3011,8 +3011,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 56,
-        "filesets": 0,
+        "works": 25,
+        "filesets": 19,
         "users": 138
       },
       "features": {
@@ -3055,17 +3055,17 @@
           "has_thumbnail": true
         },
         {
-          "id": "b4809df7-819c-4bd8-af0f-f06d6b16f80f",
-          "model": "Collection",
+          "id": "12295a74-93eb-4c3a-832e-5a8f8fb1b40a",
+          "model": "GenericWork",
           "has_thumbnail": true
         },
         {
-          "id": "12295a74-93eb-4c3a-832e-5a8f8fb1b40a",
+          "id": "5620ef37-15b3-488b-b448-c74387af7581",
           "model": "GenericWork",
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "qa": {
       "consortia": null,
@@ -3112,7 +3112,7 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 1,
+        "works": 0,
         "filesets": 0,
         "users": 138
       },
@@ -3150,7 +3150,7 @@
         "enable_standard_deposit": true
       },
       "sample_works": [],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "uw-cc": {
       "consortia": null,
@@ -3195,8 +3195,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 1,
-        "filesets": 0,
+        "works": 0,
+        "filesets": 2,
         "users": 138
       },
       "features": {
@@ -3233,7 +3233,7 @@
         "enable_standard_deposit": true
       },
       "sample_works": [],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "flyovercountry": {
       "consortia": null,
@@ -3280,8 +3280,8 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 8,
-        "filesets": 0,
+        "works": 2,
+        "filesets": 2,
         "users": 138
       },
       "features": {
@@ -3319,17 +3319,12 @@
       },
       "sample_works": [
         {
-          "id": "f30982ec-4425-4ca5-8161-efea03f4316e",
-          "model": "Collection",
-          "has_thumbnail": true
-        },
-        {
           "id": "babb705e-a41e-46e6-916d-deff8de6ad83",
           "model": "Image",
           "has_thumbnail": true
         }
       ],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "new": {
       "consortia": null,
@@ -3374,7 +3369,7 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 1,
+        "works": 0,
         "filesets": 0,
         "users": 138
       },
@@ -3412,7 +3407,7 @@
         "enable_standard_deposit": true
       },
       "sample_works": [],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     },
     "max-anon-test": {
       "consortia": null,
@@ -3457,7 +3452,7 @@
         "rights_statements": 12
       },
       "counts": {
-        "works": 1,
+        "works": 0,
         "filesets": 0,
         "users": 138
       },
@@ -3495,7 +3490,7 @@
         "enable_standard_deposit": true
       },
       "sample_works": [],
-      "pending_migrations": "ERROR: NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::Connection"
+      "pending_migrations": false
     }
   }
 }

--- a/bin/deploy-check/compare.rb
+++ b/bin/deploy-check/compare.rb
@@ -12,7 +12,11 @@
 require 'json'
 
 # A change here is a regression signal, not normal drift.
-CRITICAL = %w[available_works consortia profile_path themes schema_classes features].freeze
+CRITICAL = %w[available_works consortia profile_path themes schema_classes].freeze
+# Compared key by key rather than wholesale: an upgrade legitimately adds feature
+# flags, and failing on that buries the case worth seeing - an existing flag whose
+# value flipped.
+HASH_COMPARED = %w[features].freeze
 # Reported for awareness; these move on their own.
 INFORMATIONAL = %w[counts vocabularies schema_version sample_works
                    allowed_by_consortium pending_migrations].freeze
@@ -68,12 +72,30 @@ def compare_thumbnails(name, before, after)
   end
 end
 
-def compare_tenant(name, before, after)
-  return [["#{name}: now erroring - #{after['ERROR']}"], []] if after.key?('ERROR') && !before.key?('ERROR')
-
+# A flag that flipped is a behaviour change; one that appeared or vanished is the
+# upgrade moving underneath us, which is worth reporting but not failing.
+def compare_flags(name, before, after)
   problems = []
   notes = []
+  bf = before.is_a?(Hash) ? before : {}
+  af = after.is_a?(Hash) ? after : {}
 
+  (bf.keys & af.keys).sort.each do |flag|
+    next if bf[flag] == af[flag]
+
+    problems << "#{name}.features[#{flag}]: #{bf[flag].inspect} -> #{af[flag].inspect}"
+  end
+  added = (af.keys - bf.keys).sort
+  removed = (bf.keys - af.keys).sort
+  notes << "#{name}.features gained #{added.inspect}" if added.any?
+  notes << "#{name}.features lost #{removed.inspect}" if removed.any?
+
+  [problems, notes]
+end
+
+def compare_critical(name, before, after)
+  problems = []
+  notes = []
   CRITICAL.each do |key|
     next if before[key] == after[key]
 
@@ -82,6 +104,19 @@ def compare_tenant(name, before, after)
     else
       problems << "#{name}.#{key}: #{before[key].inspect} -> #{after[key].inspect}"
     end
+  end
+  [problems, notes]
+end
+
+def compare_tenant(name, before, after)
+  return [["#{name}: now erroring - #{after['ERROR']}"], []] if after.key?('ERROR') && !before.key?('ERROR')
+
+  problems, notes = compare_critical(name, before, after)
+
+  HASH_COMPARED.each do |key|
+    flag_problems, flag_notes = compare_flags(name, before[key], after[key])
+    problems += flag_problems
+    notes += flag_notes
   end
 
   INFORMATIONAL.each { |key| notes << "#{name}.#{key} changed" if before[key] != after[key] }
@@ -107,14 +142,44 @@ def compare(before, after)
   [problems, notes]
 end
 
+COLLAPSE_THRESHOLD = 4
+
+# "demo.themes: x -> y" splits into the tenant and the change, so the same change
+# seen on many tenants can be reported once. Lines with no tenant prefix (global.*,
+# and anything already phrased as a sentence) are left alone.
+def split_tenant(line)
+  tenant, change = line.split('.', 2)
+  return [nil, line] if change.nil? || tenant == 'global' || tenant.include?(' ')
+
+  [tenant, change]
+end
+
+# The same change across many tenants is one finding, not N. Keeps a fleet-wide
+# change readable instead of scrolling past 37 identical lines.
+def collapse(lines)
+  lines.group_by { |line| split_tenant(line).last }
+       .flat_map do |change, group|
+    tenants = group.map { |line| split_tenant(line).first }.compact.sort
+    if tenants.size >= COLLAPSE_THRESHOLD
+      ["#{change}  [#{tenants.size} tenants: #{tenants.first(3).join(', ')}, …]"]
+    elsif tenants.empty?
+      [change]
+    else
+      tenants.map { |t| "#{t}.#{change}" }
+    end
+  end
+end
+
 def report(problems, notes)
-  puts "=== REGRESSIONS (#{problems.size}) ==="
-  problems.each { |p| puts "  FAIL #{p}" }
+  collapsed = collapse(problems)
+  puts "=== REGRESSIONS (#{problems.size}#{collapsed.size == problems.size ? '' : ", #{collapsed.size} distinct"}) ==="
+  collapsed.each { |p| puts "  FAIL #{p}" }
   puts '  none - nothing in the must-not-change set moved' if problems.empty?
 
-  puts "\n=== INFORMATIONAL (#{notes.size}) ==="
-  notes.first(40).each { |n| puts "  note #{n}" }
-  puts "  ... and #{notes.size - 40} more" if notes.size > 40
+  collapsed_notes = collapse(notes)
+  puts "\n=== INFORMATIONAL (#{notes.size}#{collapsed_notes.size == notes.size ? '' : ", #{collapsed_notes.size} distinct"}) ==="
+  collapsed_notes.first(20).each { |n| puts "  note #{n}" }
+  puts "  ... and #{collapsed_notes.size - 20} more" if collapsed_notes.size > 20
 end
 
 abort "usage: #{$PROGRAM_NAME} before.json after.json" unless ARGV.length == 2

--- a/bin/deploy-check/consortium_check.rb
+++ b/bin/deploy-check/consortium_check.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Verifies consortium behaviour holds, grouped by consortium rather than by
 # tenant. The general snapshot diff catches a tenant changing; this answers
 # "is every Mobius tenant still coherent" - which is the question that matters
@@ -10,41 +12,56 @@
 problems = []
 by_consortium = {}
 
-Account.order(:name).find_each do |account|
-  Apartment::Tenant.switch(account.tenant) do
-    Site.reset! if Site.respond_to?(:reset!)
+# A work type offered to depositors with no class in the tenant's profile has no
+# field definitions behind it. A tenant with no schema at all is a different
+# condition, not an orphan.
+def orphaned_types(persisted, schema_classes)
+  return [] if schema_classes.empty?
 
-    consortium = account.part_of_consortia
-    persisted = Array(Site.instance.available_works)
-    allowed = Array(TenantWorkTypeFilter.allowed_work_types)
-    profile = TenantWorkTypeFilter.tenant_metadata_profile_path('DEFAULT').to_s
-    schema = Hyrax::FlexibleSchema.current_version
-    schema_classes = schema ? (schema['classes'] || {}).keys : []
+  persisted.reject { |w| schema_classes.include?(w) || schema_classes.include?("#{w}Resource") }
+end
 
-    # A work type offered to depositors with no class in the tenant's profile has
-    # no field definitions behind it.
-    orphaned = persisted.reject do |w|
-      schema_classes.include?(w) || schema_classes.include?("#{w}Resource")
-    end
-    orphaned = [] if schema_classes.empty? # no schema loaded: different condition, not an orphan
+def tenant_facts
+  Site.reset! if Site.respond_to?(:reset!)
+  schema = Hyrax::FlexibleSchema.current_version
+  {
+    persisted: Array(Site.instance.available_works),
+    allowed: Array(TenantWorkTypeFilter.allowed_work_types),
+    profile: TenantWorkTypeFilter.tenant_metadata_profile_path('DEFAULT').to_s,
+    schema_classes: schema ? (schema['classes'] || {}).keys : []
+  }
+end
 
-    entry = {
-      name: account.name,
-      persisted: persisted.sort,
-      allowed: allowed.sort,
-      exceeds: (persisted - allowed).sort,
-      profile: profile.split('/').last(2).join('/'),
-      schema_classes: schema_classes.size,
-      orphaned: orphaned.sort
-    }
-    (by_consortium[consortium] ||= []) << entry
+def inspect_tenant(account)
+  f = tenant_facts
+  {
+    name: account.name,
+    persisted: f[:persisted].sort,
+    allowed: f[:allowed].sort,
+    exceeds: (f[:persisted] - f[:allowed]).sort,
+    profile_full: f[:profile],
+    profile: f[:profile].split('/').last(2).join('/'),
+    schema_classes: f[:schema_classes].size,
+    orphaned: orphaned_types(f[:persisted], f[:schema_classes]).sort
+  }
+end
 
-    # The expected profile for a consortium tenant is that consortium's profile.
-    if consortium && !profile.include?("metadata_profiles/#{consortium}/")
-      problems << "#{account.name} (#{consortium}) resolves #{entry[:profile]}, expected #{consortium}/m3_profile.yaml"
-    end
-    problems << "#{account.name} offers #{orphaned.inspect} with no class in its profile" if orphaned.any?
+def problems_for(account, entry)
+  found = []
+  consortium = account.part_of_consortia
+  # The expected profile for a consortium tenant is that consortium's own.
+  if consortium && !entry[:profile_full].include?("metadata_profiles/#{consortium}/")
+    found << "#{account.name} (#{consortium}) resolves #{entry[:profile]}, " \
+             "expected #{consortium}/m3_profile.yaml"
   end
+  found << "#{account.name} offers #{entry[:orphaned].inspect} with no class in its profile" if entry[:orphaned].any?
+  found
+end
+
+Account.order(:name).find_each do |account|
+  entry = Apartment::Tenant.switch(account.tenant) { inspect_tenant(account) }
+  (by_consortium[account.part_of_consortia] ||= []) << entry
+  problems.concat(problems_for(account, entry))
 rescue StandardError => e
   problems << "#{account.name}: #{e.class}: #{e.message.lines.first.to_s.strip[0, 80]}"
 end

--- a/bin/deploy-check/consortium_check.rb
+++ b/bin/deploy-check/consortium_check.rb
@@ -1,0 +1,69 @@
+# Verifies consortium behaviour holds, grouped by consortium rather than by
+# tenant. The general snapshot diff catches a tenant changing; this answers
+# "is every Mobius tenant still coherent" - which is the question that matters
+# when a deploy touches work type or metadata profile resolution.
+#
+#   kubectl --context <ctx> -n <ns> exec -i <pod> -- bundle exec rails runner - \
+#     < bin/deploy-check/consortium_check.rb
+#
+# Strictly read-only. Non-zero exit if any tenant is incoherent.
+problems = []
+by_consortium = {}
+
+Account.order(:name).find_each do |account|
+  Apartment::Tenant.switch(account.tenant) do
+    Site.reset! if Site.respond_to?(:reset!)
+
+    consortium = account.part_of_consortia
+    persisted = Array(Site.instance.available_works)
+    allowed = Array(TenantWorkTypeFilter.allowed_work_types)
+    profile = TenantWorkTypeFilter.tenant_metadata_profile_path('DEFAULT').to_s
+    schema = Hyrax::FlexibleSchema.current_version
+    schema_classes = schema ? (schema['classes'] || {}).keys : []
+
+    # A work type offered to depositors with no class in the tenant's profile has
+    # no field definitions behind it.
+    orphaned = persisted.reject do |w|
+      schema_classes.include?(w) || schema_classes.include?("#{w}Resource")
+    end
+    orphaned = [] if schema_classes.empty? # no schema loaded: different condition, not an orphan
+
+    entry = {
+      name: account.name,
+      persisted: persisted.sort,
+      allowed: allowed.sort,
+      exceeds: (persisted - allowed).sort,
+      profile: profile.split('/').last(2).join('/'),
+      schema_classes: schema_classes.size,
+      orphaned: orphaned.sort
+    }
+    (by_consortium[consortium] ||= []) << entry
+
+    # The expected profile for a consortium tenant is that consortium's profile.
+    if consortium && !profile.include?("metadata_profiles/#{consortium}/")
+      problems << "#{account.name} (#{consortium}) resolves #{entry[:profile]}, expected #{consortium}/m3_profile.yaml"
+    end
+    problems << "#{account.name} offers #{orphaned.inspect} with no class in its profile" if orphaned.any?
+  end
+rescue StandardError => e
+  problems << "#{account.name}: #{e.class}: #{e.message.lines.first.to_s.strip[0, 80]}"
+end
+
+by_consortium.sort_by { |k, _| k.to_s }.each do |consortium, tenants|
+  label = consortium || '(none)'
+  puts "=== #{label} - #{tenants.size} tenant(s) ==="
+  profiles = tenants.map { |t| t[:profile] }.uniq
+  puts "  profiles in use: #{profiles.inspect}#{profiles.size > 1 ? '  <-- MIXED' : ''}"
+  tenants.each do |t|
+    flags = []
+    flags << "exceeds=#{t[:exceeds].inspect}" if t[:exceeds].any?
+    flags << "orphaned=#{t[:orphaned].inspect}" if t[:orphaned].any?
+    flags << 'no_schema' if t[:schema_classes].zero?
+    puts format('  %-22s works=%-46s %s', t[:name], t[:persisted].inspect, flags.join(' '))
+  end
+end
+
+puts "\n=== PROBLEMS (#{problems.size}) ==="
+problems.each { |p| puts "  FAIL #{p}" }
+puts '  none - every consortium tenant resolves its own profile' if problems.empty?
+exit(problems.empty? ? 0 : 1)

--- a/bin/deploy-check/derivative_check.rb
+++ b/bin/deploy-check/derivative_check.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Checks that A/V derivatives are present and actually playable, which the snapshot
+# cannot see: it records whether a thumbnail exists, not whether a browser can start
+# the video.
+#
+#   kubectl --context <ctx> -n <ns> exec -i <pod> -- bundle exec rails runner - \
+#     < bin/deploy-check/derivative_check.rb
+#
+# Strictly read-only. Non-zero exit if a derivative is missing or unplayable.
+#
+# An mp4 whose `moov` atom follows `mdat` has its index at the end of the file.
+# Safari will not begin progressive playback without reading that index first and
+# will not fetch the whole file to find it, so the video fails in Safari while
+# playing normally in Chrome. `ffmpeg -movflags +faststart` moves the atom to the
+# front; without it a derivative inherits whatever the uploaded file had.
+HEAD_BYTES = 8192
+
+# Driven by the app's own config so this stays correct when derivative formats change.
+# Keyed on :url, not :format - the thumbnail is declared as format "jpg" but written
+# as `-thumbnail.jpeg`, and :url is what DerivativePath builds the filename from.
+def expected_formats(kind)
+  Array(Hyrax.config.derivative_options[kind]).map { |o| o[:url].to_s }.reject(&:empty?).uniq
+rescue StandardError
+  kind == :video ? %w[thumbnail mp4] : %w[mp3 ogg]
+end
+
+def atom_order(path)
+  head = File.binread(path, HEAD_BYTES)
+  moov = head.index('moov')
+  mdat = head.index('mdat')
+  return :faststart if moov && (mdat.nil? || moov < mdat)
+  return :moov_last if mdat
+
+  :indeterminate
+rescue StandardError => e
+  "ERROR: #{e.class}"
+end
+
+# Atom order only means anything for the mp4 container; mp3 and ogg stream regardless.
+def check(id, format)
+  path = Hyrax::DerivativePath.derivative_path_for_reference(id, format).to_s
+  return :missing unless File.exist?(path)
+  return :present unless format == 'mp4'
+
+  atom_order(path)
+end
+
+problems = []
+counts = Hash.new(0)
+
+Account.order(:name).find_each do |account|
+  Apartment::Tenant.switch(account.tenant) do
+    { video: 'video', audio: 'audio' }.each do |kind, prefix|
+      formats = expected_formats(kind)
+      Hyrax::SolrService.post(q: "mime_type_ssi:#{prefix}*", rows: 25, fl: 'id')
+                        .dig('response', 'docs').to_a.each do |doc|
+        formats.each do |format|
+          state = check(doc['id'], format)
+          counts["#{format}:#{state}"] += 1
+          next if %i[faststart present].include?(state)
+
+          problems << "#{account.name} #{prefix} #{doc['id']} #{format}: #{state}"
+        end
+      end
+    end
+  end
+rescue StandardError => e
+  problems << "#{account.name}: #{e.class}: #{e.message.lines.first.to_s.strip[0, 70]}"
+end
+
+puts '=== A/V derivative playability ==='
+counts.sort.each { |state, n| puts format('  %-22s %d', state, n) }
+
+puts "\n=== PROBLEMS (#{problems.size}) ==="
+problems.first(30).each { |p| puts "  FAIL #{p}" }
+puts "  ...and #{problems.size - 30} more" if problems.size > 30
+puts '  none - every A/V derivative is present, and every mp4 starts with its moov atom' if problems.empty?
+
+puts "\nmoov_last means Safari cannot start playback while Chrome can. Fix upstream " \
+     'with `-movflags +faststart` on the mp4 derivative encode, then regenerate.'
+exit(problems.empty? ? 0 : 1)

--- a/bin/deploy-check/sequence_check.rb
+++ b/bin/deploy-check/sequence_check.rb
@@ -1,0 +1,36 @@
+# Is any tenant's id sequence behind max(id)? If so, the next insert reuses an
+# existing id and Postgres raises PG::UniqueViolation on the primary key.
+# Read-only: reads sequence state without consuming a value (last_value, not nextval).
+TABLES = %w[hyrax_flexible_schemas qa_local_authorities qa_local_authority_entries].freeze
+
+behind = []
+
+Account.order(:name).find_each do |account|
+  Apartment::Tenant.switch(account.tenant) do
+    conn = ActiveRecord::Base.connection
+    TABLES.each do |table|
+      next unless conn.table_exists?(table)
+
+      max_id = conn.select_value("SELECT COALESCE(MAX(id), 0) FROM #{table}").to_i
+      seq = conn.select_value("SELECT pg_get_serial_sequence('#{table}', 'id')")
+      next if seq.nil?
+
+      # last_value is only meaningful once the sequence has been used; is_called
+      # tells us whether it has.
+      row = conn.select_one("SELECT last_value, is_called FROM #{seq}")
+      last = row['last_value'].to_i
+      called = row['is_called']
+      # Next value the sequence will hand out.
+      nxt = called ? last + 1 : last
+      status = nxt <= max_id ? 'BEHIND' : 'ok'
+      behind << [account.name, table, max_id, nxt] if status == 'BEHIND'
+      puts format('%-6s %-20s %-30s max_id=%-6d next=%-6d rows=%d', status, account.name, table,
+                  max_id, nxt, conn.select_value("SELECT COUNT(*) FROM #{table}").to_i)
+    end
+  end
+rescue StandardError => e
+  puts "ERR    #{account.name}: #{e.class}: #{e.message.lines.first.to_s.strip[0, 70]}"
+end
+
+puts "\nSUMMARY #{behind.size} sequence(s) behind max(id)"
+behind.each { |n, t, m, x| puts "  WOULD_COLLIDE #{n}.#{t}: next=#{x} but max_id=#{m}" }

--- a/bin/deploy-check/sequence_check.rb
+++ b/bin/deploy-check/sequence_check.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Is any tenant's id sequence behind max(id)? If so, the next insert reuses an
 # existing id and Postgres raises PG::UniqueViolation on the primary key.
 # Read-only: reads sequence state without consuming a value (last_value, not nextval).

--- a/bin/deploy-check/snapshot.rb
+++ b/bin/deploy-check/snapshot.rb
@@ -34,16 +34,21 @@ snapshot = {
 }
 # rubocop:disable Metrics/BlockLength
 Account.order(:name).find_each do |account|
-  entry = { 'consortia' => account.part_of_consortia }
+  # part_of_consortia is a HykuUp addition; other knapsacks will not have the column.
+  entry = { 'consortia' => (account.part_of_consortia if account.respond_to?(:part_of_consortia)) }
   begin
     Apartment::Tenant.switch(account.tenant) do
       Site.reset! if Site.respond_to?(:reset!)
       site = Site.instance
 
       entry['available_works'] = Array(site.available_works).sort
-      entry['allowed_by_consortium'] = safe { Array(TenantWorkTypeFilter.allowed_work_types).sort }
-      entry['profile_path'] = safe do
-        TenantWorkTypeFilter.tenant_metadata_profile_path('DEFAULT').to_s.split('/').last(2).join('/')
+      # TenantWorkTypeFilter is a HykuUp addition; a knapsack without it simply has
+      # no consortium-derived work type list or per-consortium profile to record.
+      if defined?(TenantWorkTypeFilter)
+        entry['allowed_by_consortium'] = safe { Array(TenantWorkTypeFilter.allowed_work_types).sort }
+        entry['profile_path'] = safe do
+          TenantWorkTypeFilter.tenant_metadata_profile_path('DEFAULT').to_s.split('/').last(2).join('/')
+        end
       end
       entry['themes'] = {
         'home' => site.home_theme, 'show' => site.show_theme, 'search' => site.search_theme
@@ -81,8 +86,16 @@ Account.order(:name).find_each do |account|
             'has_thumbnail' => Array(d['thumbnail_path_ss']).first.present? }
         end
       end
+      # migration_context moved from the connection to the pool in newer Rails, so
+      # try both rather than recording an error on whichever side of that we land.
       entry['pending_migrations'] = safe do
-        ActiveRecord::Base.connection.migration_context.needs_migration?
+        pool = ActiveRecord::Base.connection_pool
+        ctx = if pool.respond_to?(:migration_context)
+                pool.migration_context
+              elsif ActiveRecord::Base.connection.respond_to?(:migration_context)
+                ActiveRecord::Base.connection.migration_context
+              end
+        ctx&.needs_migration?
       end
     end
   rescue StandardError => e

--- a/bin/deploy-check/snapshot.rb
+++ b/bin/deploy-check/snapshot.rb
@@ -16,6 +16,21 @@ ensure
   nil
 end
 
+# This Solr config returns 0 for `a OR b` even where each side alone matches, so
+# every count is a single-clause query summed in Ruby. Colons in a model name have
+# to be escaped or the term is read as a field.
+def solr_count(model)
+  Hyrax::SolrService.post(q: "has_model_ssim:#{model.gsub(':') { '\\:' }}", rows: 0)
+                    .dig('response', 'numFound').to_i
+end
+
+# Counting "everything that is not a FileSet or Collection" also counts
+# FileMetadata, ACLs and containers, which inflates the total by an order of
+# magnitude. Only registered work types are works.
+WORK_MODELS = lambda do
+  Hyrax.config.registered_curation_concern_types.flat_map { |m| [m, "#{m}Resource"] }
+end
+
 snapshot = {
   'global' => {
     'account_count' => safe { Account.count },
@@ -65,10 +80,8 @@ Account.order(:name).find_each do |account|
       end
       entry['counts'] = safe do
         {
-          'works' => Hyrax::SolrService.post(q: 'has_model_ssim:* AND -has_model_ssim:FileSet AND -has_model_ssim:*Collection*', rows: 0)
-                                       .dig('response', 'numFound'),
-          'filesets' => Hyrax::SolrService.post(q: 'has_model_ssim:FileSet OR has_model_ssim:"Hyrax::FileSet"', rows: 0)
-                                          .dig('response', 'numFound'),
+          'works' => WORK_MODELS.call.sum { |m| solr_count(m) },
+          'filesets' => solr_count('FileSet') + solr_count('Hyrax::FileSet'),
           'users' => User.count
         }
       end
@@ -78,9 +91,14 @@ Account.order(:name).find_each do |account|
       # A sample public work per tenant, so a post-deploy run can re-fetch the
       # same ids and confirm they still render with the same derivatives.
       entry['sample_works'] = safe do
-        Hyrax::SolrService.post(q: 'visibility_ssi:open AND -has_model_ssim:FileSet', rows: 3,
+        models = WORK_MODELS.call
+        # Over-fetch and filter in Ruby: the query cannot OR the work models together,
+        # and without that filter the first rows back are ACLs and file metadata.
+        Hyrax::SolrService.post(q: 'visibility_ssi:open AND -has_model_ssim:FileSet', rows: 50,
                                 fl: 'id,has_model_ssim,thumbnail_path_ss', sort: 'system_create_dtsi asc')
                           .dig('response', 'docs').to_a
+                          .select { |d| Array(d['has_model_ssim']).any? { |m| models.include?(m) } }
+                          .first(3)
                           .map do |d|
           { 'id' => d['id'], 'model' => Array(d['has_model_ssim']).first,
             'has_thumbnail' => Array(d['thumbnail_path_ss']).first.present? }

--- a/lib/hyku_knapsack/version.rb
+++ b/lib/hyku_knapsack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HykuKnapsack
-  VERSION = "7.2.0"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
The snapshot diff in #703 answers "did this tenant change". It can't answer "is every Mobius tenant still coherent", which is the question when a deploy touches work type or metadata profile resolution. `consortium_check.rb` groups by consortium and fails when a tenant resolves another consortium's profile, or offers a work type with no class in its own.

Worth arguing with:

- **The orphan check found a real pre-existing bug, not a cosmetic one.** A work type in `available_works` with no class in the tenant's flexible schema never gets the metadata mixin, so building its form raises `NoMethodError: undefined method 'depositor'` and the depositor sees a 500. Verified against production: `MobiusWork` raises on the `main` tenant while `GenericWork` builds 26 terms fine. **Nine tenants are in that state right now**, eight `consortia=nil` plus `stjude`. Nothing here changes that; the point is having it on record so it can't be mistaken for v1.1.0 fallout. Tracked in #707.
- The 17 `mobius` and 2 `unca` tenants are all clean and on their own profiles, which is the reassuring half.
- Stacked on top of #703 rather than appended to it, per the review note there.

Two fixes since the first push, both found by porting this to PALS in notch8/palni_palci_knapsack#723:

- **The pod selector didn't resolve everywhere.** It matched `-hyrax-` in the pod name, which PALS production doesn't have; it returned empty and `kubectl exec` failed with nothing useful. Now excludes non-web components instead, verified on PALS production and friends and on HykuUp production and staging. The README was also missing the `sed` that strips Rails boot warnings, so its captures wouldn't have parsed.
- **Added the browser pass to `SKILL.md`.** The snapshot never renders a page, so a partial that raises or a card that renders blank is invisible to it. Driving a browser through the Playwright MCP server on a few representative tenants covers that, and is what actually confirmed compound cards and the vocabulary dashboard during the release.

Testing: run against production read-only, exits 1 with the nine problems listed; pre-deploy output committed under `baselines/`.


Next week: /deploy-regression-check, or just say "capture the deploy baseline" and it matches on description.